### PR TITLE
Add tracing for MVC dependency resolvers.

### DIFF
--- a/source/Glimpse.Net/Glimpse.Net.csproj
+++ b/source/Glimpse.Net/Glimpse.Net.csproj
@@ -57,6 +57,9 @@
     <Compile Include="Converter\RouteValueDictionaryConverter.cs" />
     <Compile Include="Extentions.cs" />
     <Compile Include="Plugin\Mvc\Binders.cs" />
+    <Compile Include="Plugin\Mvc\Dependencies.cs" />
+    <Compile Include="Plumbing\GlimpseDependencyMetadata.cs" />
+    <Compile Include="Plumbing\GlimpseDependencyResolver.cs" />
     <Compile Include="Plumbing\GlimpseActionFilter.cs" />
     <Compile Include="Plumbing\GlimpseActionInvoker.cs" />
     <Compile Include="Plumbing\GlimpseAuthorizationFilter.cs" />

--- a/source/Glimpse.Net/GlimpseConstants.cs
+++ b/source/Glimpse.Net/GlimpseConstants.cs
@@ -5,6 +5,7 @@
         public const string Views = "Glimpse.Views";
         public const string ViewEngine = "Glimpse.ViewEngine";
         public const string Data = "__glimpseData";
+        public const string Dependencies = "Glimpse.Dependencies";
         public const string ClientName = "ClientName";
         public const string ClientRequestId = "ClientRequestID";
         public const string ActionDescriptor = "Glimpse.ActionDescriptor";

--- a/source/Glimpse.Net/Plugin/Mvc/Dependencies.cs
+++ b/source/Glimpse.Net/Plugin/Mvc/Dependencies.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+using Glimpse.Net.Plumbing;
+using Glimpse.Protocol;
+
+namespace Glimpse.Net.Plugin.Mvc
+{
+    [GlimpsePlugin(ShouldSetupInInit = true)]
+    public class Dependencies : IGlimpsePlugin
+    {
+        public object GetData(HttpApplication application)
+        {
+            var calls = application.Context.Items[GlimpseConstants.Dependencies] as IList<GlimpseDependencyMetadata>;
+            if(calls == null)
+            {
+                return null;
+            }
+            var header = new[] { "Call", "Requested Type", "Returned Types" };
+            var values = calls.Select(
+                data => new[]
+                            {
+                                data.Call,
+                                data.RequestedType.FullName,
+                                String.Join(", ", data.ReturnedTypes.Select(t => t.FullName)),
+                            });
+
+            return new [] { header }.Concat(values).ToArray();
+        }
+
+        public void SetupInit(HttpApplication application)
+        {
+            var setResolver = DependencyResolver.Current;
+            if (setResolver != null && !(setResolver is GlimpseDependencyResolver))
+            {
+                DependencyResolver.SetResolver(new GlimpseDependencyResolver(setResolver));
+            }
+        }
+
+        public string Name
+        {
+            get { return "Dependencies"; }
+        }
+    }
+}

--- a/source/Glimpse.Net/Plumbing/GlimpseDependencyMetadata.cs
+++ b/source/Glimpse.Net/Plumbing/GlimpseDependencyMetadata.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Glimpse.Net.Plumbing
+{
+    public class GlimpseDependencyMetadata
+    {
+        public string Call { get; set; }
+        public Type RequestedType { get; set; }
+        public IEnumerable<Type> ReturnedTypes { get; set; }
+    }
+}

--- a/source/Glimpse.Net/Plumbing/GlimpseDependencyResolver.cs
+++ b/source/Glimpse.Net/Plumbing/GlimpseDependencyResolver.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+
+namespace Glimpse.Net.Plumbing
+{
+    public class GlimpseDependencyResolver : IDependencyResolver
+    {
+        private readonly IDependencyResolver resolver;
+
+        public GlimpseDependencyResolver(IDependencyResolver resolver)
+        {
+            this.resolver = resolver;
+        }
+
+        public object GetService(Type serviceType)
+        {
+            var result = this.resolver.GetService(serviceType);
+            Store.Add(new GlimpseDependencyMetadata
+                {
+                    Call = "GetService",
+                    RequestedType = serviceType,
+                    ReturnedTypes = result == null ? Enumerable.Empty<Type>() : new [ ] { result.GetType() },
+                });
+            return BuildUp(serviceType, result);
+        }
+
+        public IEnumerable<object> GetServices(Type serviceType)
+        {
+            var services = this.resolver.GetServices(serviceType);
+            Store.Add(new GlimpseDependencyMetadata
+            {
+                Call = "GetServices",
+                RequestedType = serviceType,
+                ReturnedTypes = (services ?? Enumerable.Empty<object>()).Select(s => s.GetType()),
+            });
+            return services == null ? null : services.Select(o => BuildUp(serviceType, o));
+        }
+
+        public IList<GlimpseDependencyMetadata> Store
+        {
+            get
+            {
+                var items = HttpContext.Current.Items;
+                var store = items[GlimpseConstants.Dependencies] as IList<GlimpseDependencyMetadata>;
+                if (store == null) items[GlimpseConstants.Dependencies] = store = new List<GlimpseDependencyMetadata>();
+
+                return store;
+            }
+        }
+
+        private static object BuildUp(Type serviceType, object o)
+        {
+            //TODO: Wrap with Glimpse objects
+            return o;
+        }
+    }
+}


### PR DESCRIPTION
To help debug an issue I created a plugin for tracing the calls to IDependencyResolver.  I've moved it over into a Glimpse fork so I could contribute it back.  Especially since this implementation could be confused when the final IDependencyResolver code is written.

Unfortunately I couldn't get the test project to compile so I wasn't able to add any tests.

I hope this is helpful!
