### PR TITLE
When validating by IP, check the HTTP_X_FORWARDED_FOR

### DIFF
--- a/source/Glimpse.Core/Configuration/GlimpseConfiguration.cs
+++ b/source/Glimpse.Core/Configuration/GlimpseConfiguration.cs
@@ -18,6 +18,18 @@ namespace Glimpse.Core.Configuration
                 return result;
             }
         }
+        
+        [ConfigurationProperty("allowIPForwarding", DefaultValue = "false", IsRequired = false)]
+        public bool AllowIPForwarding
+        {
+            set { this["allowIPForwarding"] = value; }
+            get
+            {
+                bool result; //false which matches the default above
+                bool.TryParse(this["allowIPForwarding"].ToString(), out result);
+                return result;
+            }
+        }
 
         [ConfigurationProperty("loggingEnabled", DefaultValue = "false", IsRequired = false)]
         public bool LoggingEnabled

--- a/source/Glimpse.Core/Validator/IpAddressValidator.cs
+++ b/source/Glimpse.Core/Validator/IpAddressValidator.cs
@@ -11,20 +11,24 @@ namespace Glimpse.Core.Validator
         {
             if (configuration.IpAddresses.Count == 0) return true; //no configured list, allow all IP's
 
-            var userIpAddress = GetUserIpAddress(context);
+            var userIpAddress = GetUserIpAddress(context, configuration.AllowIPForwarding);
 
             return configuration.IpAddresses.Contains(userIpAddress);
         }
 
-        static string GetUserIpAddress(HttpContextBase context)
+        static string GetUserIpAddress(HttpContextBase context, bool allowIPForwarding)
         {
-            // Source http://support.appharbor.com/discussions/problems/681-requestuserhostaddress
-            var forwardedFor = context.Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
-            if (!string.IsNullOrEmpty(forwardedFor))
+            if (allowIPForwarding)
             {
-                // sometimes HTTP_X_FORWARDED_FOR returns multiple IP's
-                return forwardedFor.Split(',').Last();
+                // Source http://support.appharbor.com/discussions/problems/681-requestuserhostaddress
+                var forwardedFor = context.Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
+                if (!string.IsNullOrEmpty(forwardedFor))
+                {
+                    // sometimes HTTP_X_FORWARDED_FOR returns multiple IP's
+                    return forwardedFor.Split(',').Last();
+                }
             }
+
             return context.Request.UserHostAddress;
         }
     }


### PR DESCRIPTION
When behind a load balancer HTTP_X_FORWARDED_FOR should be used to get the users IP.
See http://support.appharbor.com/discussions/problems/681-requestuserhostaddress
