### PR TITLE
Putting in handler and module for WebForms sample so it runs out of the box.

### DIFF
--- a/source/Glimpse.Sample.WebForms/Web.config
+++ b/source/Glimpse.Sample.WebForms/Web.config
@@ -50,6 +50,13 @@
       </providers>
     </roleManager>
 
+    <httpHandlers>
+      <add path="/Glimpse.axd" type="Glimpse.Core.Handler" verb="GET,POST"/>
+    </httpHandlers>
+
+    <httpModules>
+      <add name="Glimpse" type="Glimpse.Core.Module"/>
+    </httpModules>
   </system.web>
 
   <system.webServer>


### PR DESCRIPTION
While Glimpse.Sample.WebForms had <glimpse enabled="true" /> in web.config, it didn't have the httpHandlers and httpModule registrations for it to just run with an F5 in VS.
