### PR TITLE
Display object size in bytes on the session tab, along with total

### DIFF
--- a/source/Glimpse.Core/Plugin/Session.cs
+++ b/source/Glimpse.Core/Plugin/Session.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Web;
 using Glimpse.Core.Extensibility;
 
@@ -8,6 +10,8 @@ namespace Glimpse.Core.Plugin
     [GlimpsePlugin(SessionRequired = true)]
     internal class Session : IGlimpsePlugin, IProvideGlimpseHelp
     {
+        internal static string[] Header = new[] {"Key", "Value", "Type", "Size (bytes)"};
+
         public string Name
         {
             get { return "Session"; }
@@ -19,20 +23,23 @@ namespace Glimpse.Core.Plugin
 
             if (session == null) return null;
 
-            var result = new List<object[]>
-                             {
-                                 new[] {"Key", "Value", "Type"}
-                             };
+            var result = new List<object[]> { Header };
 
             foreach (var key in session.Keys)
             {
                 var keyString = key.ToString();
                 var value = session[keyString];
                 var type = value != null ? value.GetType().ToString() : null;
-                result.Add(new[]{keyString, value, type});
+                result.Add(new[]{keyString, value, type,GetObjectSize(value)});
             }
 
-            if (result.Count > 1) return result;
+            if (result.Count > 1)
+            {
+                var sessionSize = result.Sum(o => o[3] as long?);
+                result.Add(new object[] {"Total Session Size", "", "(calculated)", sessionSize});
+
+                return result;
+            }
 
             return null;
         }
@@ -44,6 +51,18 @@ namespace Glimpse.Core.Plugin
         public string HelpUrl
         {
             get { return "http://getGlimpse.com/Help/Plugin/Session"; }
+        }
+
+        private static long GetObjectSize(object obj)
+        {
+            if (obj == null)
+                return 0;
+
+            using (var stream = new MemoryStream())
+            {
+                new BinaryFormatter().Serialize(stream, obj);
+                return stream.Length;
+            }
         }
     }
 }


### PR DESCRIPTION
This addition adds a Size (bytes) column to the Session tab that will show the binary serialized size of each object in session. It also adds a calculated total the bottom of the tab.
