### PR TITLE
Allow glimpse.axd path to be moved in web.config for httpHandler

### DIFF
--- a/source/Glimpse.Test.Core/Extensions/HttpContextBaseExtensionsTest.cs
+++ b/source/Glimpse.Test.Core/Extensions/HttpContextBaseExtensionsTest.cs
@@ -1,0 +1,58 @@
+using System.Web.Configuration;
+using Glimpse.Core;
+using Glimpse.Core.Extensions;
+using System.Web;
+using Moq;
+using NUnit.Framework;
+
+namespace Glimpse.Test.Core.Extensions
+{
+    [TestFixture]
+    public class HttpContextBaseExtensionsTest
+    {
+        [Test]
+        public void ResourceRoot_NoHandlers_DefaultsPath()
+        {
+            var rootPath= HttpContextBaseExtensions.GetResourceRootFromHandler(Handlers);
+
+            Assert.AreEqual("~/", rootPath);
+        }
+
+        [Test]
+        public void ResourceRoot_BasePath()
+        {
+            Handlers.Handlers.Add(new HttpHandlerAction("Glimpse.axd", typeof(Handler).FullName, "GET,POST"));
+            var rootPath= HttpContextBaseExtensions.GetResourceRootFromHandler(Handlers);
+
+            Assert.AreEqual("~/", rootPath);
+        }
+
+        [Test]
+        public void ResourceRoot_WithSubDirectory()
+        {
+            Handlers.Handlers.Add(new HttpHandlerAction("MyDirectory/Glimpse.axd", typeof(Handler).FullName, "GET,POST"));
+            var rootPath= HttpContextBaseExtensions.GetResourceRootFromHandler(Handlers);
+
+            Assert.AreEqual("~/MyDirectory/", rootPath);
+        }
+
+        [Test]
+        public void ResourceRoot_WithPrecedingSlash()
+        {
+            Handlers.Handlers.Add(new HttpHandlerAction("/Glimpse.axd", typeof(Handler).FullName, "GET,POST"));
+            var rootPath= HttpContextBaseExtensions.GetResourceRootFromHandler(Handlers);
+
+            Assert.AreEqual("~/", rootPath);
+        }
+
+        public HttpHandlersSection Handlers { get; set; }
+        public Mock<HttpContextBase> Context { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            Handlers = new HttpHandlersSection();
+            Context = new Mock<HttpContextBase>();
+        }
+    }
+}

--- a/source/Glimpse.Test.Core/Glimpse.Test.Core.csproj
+++ b/source/Glimpse.Test.Core/Glimpse.Test.Core.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\HttpContextBaseExtensionsTest.cs" />
     <Compile Include="ModuleTest.cs" />
     <Compile Include="Plugin\RequestTest.cs" />
     <Compile Include="Plugin\ServerTest.cs" />


### PR DESCRIPTION
Within my company, placing a new .axd in the web root (especially one with the type of information that Glimpse provides) is a security issue. We have certain controls already in place for access to particular directories.

This change allows altering where the HttpHandler for Glimpse lives. By retrieving alternate path information from the web.config, Glimpse.axd can be relocated seamlessly to a more secure location. If web.config values aren't found, it simply defaults to the root path as before.
