### PR TITLE
ADO Support - Fix - GlimpseProfileDbConnectionFactory compilation.

### DIFF
--- a/source/Glimpse.EF/Plumbing/Injectors/WrapDbConnectionFactories.cs
+++ b/source/Glimpse.EF/Plumbing/Injectors/WrapDbConnectionFactories.cs
@@ -32,7 +32,7 @@ namespace Glimpse.EF.Plumbing.Injectors
                 var assembliesToReference = new[] { type.Assembly, typeof(DbConnection).Assembly, typeof(AdoPipelineInitiator).Assembly, typeof(TypeConverter).Assembly };
 
                 var generatedAssembly = CreateAssembly(code, assembliesToReference);
-                var generatedType = generatedAssembly.GetType("Glimpse.EF.Plumbing.GlimpseProfileDbProviderFactory");
+                var generatedType = generatedAssembly.GetType("Glimpse.EF.Plumbing.Profiler.GlimpseProfileDbProviderFactory");
                 generatedType.GetMethod("Initialize").Invoke(null, null);
 
                 Logger.Info("AdoPipelineInitiator: Finished to inject ConnectionFactory");

--- a/source/Glimpse.EF/Plumbing/Models/GlimpseDbQueryCommandMetadata.cs
+++ b/source/Glimpse.EF/Plumbing/Models/GlimpseDbQueryCommandMetadata.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Glimpse.EF.Plumbing.Models
 {
-    internal class GlimpseDbQueryCommandMetadata 
+    public class GlimpseDbQueryCommandMetadata 
     {
         public GlimpseDbQueryCommandMetadata(string id, string connectionId)
         {

--- a/source/Glimpse.EF/Plumbing/Models/GlimpseDbQueryCommandParameterMetadata.cs
+++ b/source/Glimpse.EF/Plumbing/Models/GlimpseDbQueryCommandParameterMetadata.cs
@@ -1,6 +1,6 @@
 namespace Glimpse.EF.Plumbing.Models
 {
-    internal class GlimpseDbQueryCommandParameterMetadata
+    public class GlimpseDbQueryCommandParameterMetadata
     {
         public string Name { get; set; }
         public object Value { get; set; }

--- a/source/Glimpse.EF/Plumbing/Models/GlimpseDbQueryConnectionMetadata.cs
+++ b/source/Glimpse.EF/Plumbing/Models/GlimpseDbQueryConnectionMetadata.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Glimpse.EF.Plumbing.Models
 {
-    internal class GlimpseDbQueryConnectionMetadata
+    public class GlimpseDbQueryConnectionMetadata
     {
         private static readonly KeyValuePair<string, GlimpseDbQueryCommandMetadata> DefaultCommandKey = default(KeyValuePair<string, GlimpseDbQueryCommandMetadata>);
         private GlimpseDbQueryTransactionMetadata TempTransaction { get; set; }

--- a/source/Glimpse.EF/Plumbing/Models/GlimpseDbQueryMetadata.cs
+++ b/source/Glimpse.EF/Plumbing/Models/GlimpseDbQueryMetadata.cs
@@ -2,7 +2,7 @@
 
 namespace Glimpse.EF.Plumbing.Models
 {
-    internal class GlimpseDbQueryMetadata
+    public class GlimpseDbQueryMetadata
     {
         public GlimpseDbQueryMetadata()
         {

--- a/source/Glimpse.EF/Plumbing/Models/GlimpseDbQueryTransactionMetadata.cs
+++ b/source/Glimpse.EF/Plumbing/Models/GlimpseDbQueryTransactionMetadata.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Glimpse.EF.Plumbing.Models
 {
-    internal class GlimpseDbQueryTransactionMetadata 
+    public class GlimpseDbQueryTransactionMetadata 
     {
         public GlimpseDbQueryTransactionMetadata(string transactionId, string connectionId)
         {

--- a/source/Glimpse.EF/Plumbing/Profiler/GlimpseProfileDbConnection.cs
+++ b/source/Glimpse.EF/Plumbing/Profiler/GlimpseProfileDbConnection.cs
@@ -6,7 +6,7 @@ using System.Transactions;
 
 namespace Glimpse.EF.Plumbing.Profiler
 {
-    internal class GlimpseProfileDbConnection : DbConnection
+    public class GlimpseProfileDbConnection : DbConnection
     {
         public GlimpseProfileDbConnection(DbConnection inner, DbProviderFactory providerFactory, ProviderStats stats, Guid connectionId)
         {

--- a/source/Glimpse.EF/Plumbing/Profiler/GlimpseProfileDbConnectionFactory.cs
+++ b/source/Glimpse.EF/Plumbing/Profiler/GlimpseProfileDbConnectionFactory.cs
@@ -14,9 +14,9 @@ namespace Glimpse.EF.Plumbing.Profiler
 
         public GlimpseProfileDbProviderFactory(IDbConnectionFactory inner, DbProviderFactory factory, ProviderStats stats)
         {
-            inner = inner;
-            factory = factory;
-            stats = stats;
+            this.inner = inner;
+            this.factory = factory;
+            this.stats = stats;
         }
 
         public DbConnection CreateConnection(string nameOrConnectionString)

--- a/source/Glimpse.EF/Plumbing/Profiler/GlimpseProfileDbProviderFactory.cs
+++ b/source/Glimpse.EF/Plumbing/Profiler/GlimpseProfileDbProviderFactory.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 
 namespace Glimpse.EF.Plumbing.Profiler
 {
-    internal class GlimpseProfileDbProviderFactory<TProviderFactory> : DbProviderFactory, IServiceProvider
+    public class GlimpseProfileDbProviderFactory<TProviderFactory> : DbProviderFactory, IServiceProvider
         where TProviderFactory : DbProviderFactory
     {
         public static readonly GlimpseProfileDbProviderFactory<TProviderFactory> Instance;


### PR DESCRIPTION
Made more classes public. Need to be visible to GlimpseProfileDbConnectionFactory. Fixed not setting members in constructor and using wrong type name for GlimpseProfileDbConnectionFactory.
