### PR TITLE
Duplicating Html When Using Web Forms

### DIFF
--- a/source/Glimpse.Core/Plumbing/GlimpseResponseFilter.cs
+++ b/source/Glimpse.Core/Plumbing/GlimpseResponseFilter.cs
@@ -10,7 +10,6 @@ namespace Glimpse.Core.Plumbing
     //Heavily influenced by http://www.4guysfromrolla.com/articles/120308-1.aspx
     public class GlimpseResponseFilter : MemoryStream
     {
-        internal StringBuilder ResponseContent { get; set; }
         internal Stream OutputStream { get; set; }
         internal HttpContextBase Context { get; set; }
 
@@ -18,7 +17,6 @@ namespace Glimpse.Core.Plumbing
 
         public GlimpseResponseFilter(Stream output, HttpContextBase context)
         {
-            ResponseContent = new StringBuilder();
             OutputStream = output;
             Context = context;
         }
@@ -27,12 +25,9 @@ namespace Glimpse.Core.Plumbing
         {
             // Convert the content in buffer to a string
             string contentInBuffer = UTF8Encoding.UTF8.GetString(buffer);
-
             // Buffer content in responseContent until we reach the end of the page's markup
-            ResponseContent.Append(contentInBuffer);
 
-            var contentString = ResponseContent.ToString();
-            if (bodyEnd.IsMatch(contentString) && Context.GetGlimpseMode() == GlimpseMode.On)
+            if (bodyEnd.IsMatch(contentInBuffer) && Context.GetGlimpseMode() == GlimpseMode.On)
             {
                 var dataPath = HttpUtility.HtmlAttributeEncode(Context.GlimpseResourcePath("data.js") + "&id=" + Context.GetGlimpseRequestId());
                 var clientPath = HttpUtility.HtmlAttributeEncode(Context.GlimpseResourcePath("client.js"));
@@ -40,7 +35,7 @@ namespace Glimpse.Core.Plumbing
                 var html = string.Format(@"<script type='text/javascript' id='glimpseData' src='{0}'></script><script type='text/javascript' id='glimpseClient' src='{1}'></script></body>", dataPath, clientPath);
                 
                 // Add glimpse output script
-                string bodyCloseWithScript = bodyEnd.Replace(contentString,html);
+                string bodyCloseWithScript = bodyEnd.Replace(contentInBuffer,html);
 
                 // Write content to the outputStream
                 byte[] outputBuffer = UTF8Encoding.UTF8.GetBytes(bodyCloseWithScript);

--- a/source/Glimpse.Test.Core/Glimpse.Test.Core.csproj
+++ b/source/Glimpse.Test.Core/Glimpse.Test.Core.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Plugin\ServerTest.cs" />
     <Compile Include="Plugin\SessionTest.cs" />
     <Compile Include="Plugin\TraceTest.cs" />
+    <Compile Include="Plumbing\GlimpseResponseFilterTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Glimpse.Test.Core/Plumbing/GlimpseResponseFilterTest.cs
+++ b/source/Glimpse.Test.Core/Plumbing/GlimpseResponseFilterTest.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Glimpse.Core.Plumbing;
+using System.IO;
+using Moq;
+using System.Web;
+using Glimpse.Core;
+
+namespace Glimpse.Test.Core.Plumbing
+{
+    [TestFixture]
+    public class GlimpseResponseFilterTest
+    {
+        HttpContextBase httpContext;
+        [Test]
+        public void OutputDoesNotDuplicateHtmlIfWriteCalledTwice()
+        {
+            var encoding = UTF8Encoding.UTF8;
+            string htmlFirst = "<html><head><title>THETITLE</title></head><body>";
+            string htmlLast = "</body></html>";
+
+            MemoryStream stream = new MemoryStream();
+            var filter = new GlimpseResponseFilter(stream, httpContext);
+            var firstBytes = encoding.GetBytes(htmlFirst);
+            var secondBytes = encoding.GetBytes(htmlLast);
+            filter.Write(firstBytes, 0, firstBytes.Count());
+            filter.Write(secondBytes, 0, secondBytes.Count());
+            var html = encoding.GetString(stream.ToArray());
+            Assert.That(CountSubstrings(html, "THETITLE") == 1, "The Title html element was duplicated");
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            var httpContextBaseMock = new Moq.Mock<HttpContextBase>();
+
+            var httpRequestBase = new Moq.Mock<HttpRequestBase>();
+            httpRequestBase.SetupGet(r => r.ApplicationPath).Returns(@"\");
+            httpContextBaseMock.SetupGet(c => c.Items).Returns(new Dictionary<string, object>());
+            httpRequestBase.SetupGet(r => r.Cookies).Returns(new HttpCookieCollection());
+            httpRequestBase.Object.Cookies.Add(new HttpCookie(GlimpseConstants.CookieModeKey, "On"));
+
+            httpContextBaseMock.SetupGet(c => c.Request).Returns(httpRequestBase.Object);
+            httpContext = httpContextBaseMock.Object;
+        }
+
+        public int CountSubstrings(string @string, string substringToCount)
+        {
+            return @string.Select((c, i) => @string.Substring(i)).Count(sub => sub.StartsWith(substringToCount));
+        }
+        
+    }
+}


### PR DESCRIPTION
When using web forms, turning on glimpse is resulting in everything before and including the form element beginning being duplicated so title element, any html before form element and crucially, viewstate. It seems web forms, at least the Microsoft version of it, calls any response filter's Write method twice: once with the html up to and including html rendered by beginning of asp:form and once with all the html after this. The current implementation of GlimpseResponseFilter sends to output any input that does not include end body tag AND saves it to a StringBuilder. When the write method is called again, it outputs the whole of the html stored in the StringBuilder resulting in duplicated html. If a user clicks a button on a page where viewstate has been duplicated a "The state information is invalid for this page and might be corrupted" error is generated.

This commit includes a test that invokes the filter's Write like web forms does and a fix for this issue.
