### PR TITLE
Implement Stream.Flush method and forward it through to OutputStream

### DIFF
--- a/source/Glimpse.Core/Plumbing/GlimpseResponseFilter.cs
+++ b/source/Glimpse.Core/Plumbing/GlimpseResponseFilter.cs
@@ -8,7 +8,7 @@ using Glimpse.Core.Extensions;
 namespace Glimpse.Core.Plumbing
 {
     //Heavily influenced by http://www.4guysfromrolla.com/articles/120308-1.aspx
-    public class GlimpseResponseFilter : MemoryStream
+    public class GlimpseResponseFilter : Stream
     {
         internal Stream OutputStream { get; set; }
         internal HttpContextBase Context { get; set; }
@@ -51,6 +51,52 @@ namespace Glimpse.Core.Plumbing
         public override void Flush()
         {
             OutputStream.Flush();
+        }
+
+        public override bool CanRead
+        {
+            get { return OutputStream.CanRead; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return OutputStream.CanSeek; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return OutputStream.CanWrite; }
+        }
+
+        public override long Length
+        {
+            get { return OutputStream.Length; }
+        }
+
+        public override long Position
+        {
+            get { return OutputStream.Position; }
+            set { OutputStream.Position = value; }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return OutputStream.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return OutputStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            OutputStream.SetLength(value);
+        }
+
+        public override void Close()
+        {
+            OutputStream.Close();
         }
     }
 }


### PR DESCRIPTION
Other libraries can implement filters, which Glimpse tries to wrap. However, `GlimpseResponseFilter` only forwards on `Write` methods to wrapped stream, and other implementations (for instance Coolite/Ext.NET) perform writing to the actual `Response` stream only when `Flush`ed. As the `GlimpseResponseFilter` doesn't implement `Flush`, the wrapped stream's `Flush` method is never called, and the `Response` stream is never written to, resulting in an empty response.

Ultimately, `GlimpseResponseFilter` should probably inherit `Stream` rather than `MemoryStream` and implement all `Stream` methods, simply forwarding on any it doesn't need to intercept to `OutputStream`
