### PR TITLE
Support for plugin directories hosted outside of ~/bin

### DIFF
--- a/source/Glimpse.Core/Configuration/GlimpseConfiguration.cs
+++ b/source/Glimpse.Core/Configuration/GlimpseConfiguration.cs
@@ -103,6 +103,16 @@ namespace Glimpse.Core.Configuration
             }
         }
 
+        [ConfigurationProperty("pluginDirectories", IsRequired = false)]
+        public PluginDirectoryCollection PluginDirectories
+        {
+            set { this["pluginDirectories"] = value; }
+            get
+            {
+                return this["pluginDirectories"] as PluginDirectoryCollection;
+            }
+        }
+
         [ConfigurationProperty("urlBlacklist", IsRequired = false)]
         public UrlBlacklistCollection UrlBlackList
         {

--- a/source/Glimpse.Core/Configuration/PluginDirectory.cs
+++ b/source/Glimpse.Core/Configuration/PluginDirectory.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+
+namespace Glimpse.Core.Configuration
+{
+    /// <summary>
+    /// Directory containing plugins
+    /// </summary>
+    public class PluginDirectory : ConfigurationElement
+    {
+        [ConfigurationProperty("directory")]
+        public string Directory
+        {
+            get
+            { 
+                return this["directory"].ToString();
+            }
+            set { this["directory"] = value; }
+        }
+
+        public override string ToString()
+        {
+            return Directory;
+        }
+    }
+}

--- a/source/Glimpse.Core/Configuration/PluginDirectoryCollection.cs
+++ b/source/Glimpse.Core/Configuration/PluginDirectoryCollection.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+
+namespace Glimpse.Core.Configuration
+{
+    public class PluginDirectoryCollection : ConfigurationElementCollection
+    {
+        public PluginDirectoryCollection()
+        {
+            BaseAdd(new PluginDirectory { Directory = "bin" });
+        }
+
+        public PluginDirectory this[int index]
+        {
+            get { return BaseGet(index) as PluginDirectory; }
+            set
+            {
+                if (BaseGet(index) != null)
+                {
+                    BaseRemoveAt(index);
+                }
+                BaseAdd(index, value);
+            }
+        }
+
+        public void Add(PluginDirectory address)
+        {
+            BaseAdd(address);
+        }
+
+        public void Clear()
+        {
+            BaseClear();
+        }
+
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new PluginDirectory();
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            return element;
+        }
+
+        public IEnumerable<string> DirectoryNames 
+        {
+            get
+            {
+                foreach (PluginDirectory directory in this)
+                {
+                    yield return directory.ToString();
+                }
+            }
+        }
+    }
+}

--- a/source/Glimpse.Core/Glimpse.Core.csproj
+++ b/source/Glimpse.Core/Glimpse.Core.csproj
@@ -78,6 +78,8 @@
     <Compile Include="Configuration\IpCollection.cs" />
     <Compile Include="Configuration\GlimpseMode.cs" />
     <Compile Include="Configuration\PluginBlacklistCollection.cs" />
+    <Compile Include="Configuration\PluginDirectory.cs" />
+    <Compile Include="Configuration\PluginDirectoryCollection.cs" />
     <Compile Include="Configuration\UrlBlacklistCollection.cs" />
     <Compile Include="Converter\AuthenticationSectionConverter.cs" />
     <Compile Include="Converter\CustomErrorsSectionConverter.cs" />

--- a/source/Glimpse.Core/Module.cs
+++ b/source/Glimpse.Core/Module.cs
@@ -330,7 +330,7 @@ namespace Glimpse.Core
         {
             var batch = new CompositionBatch();
 
-            var directoryCatalog = new BlacklistedSafeDirectoryCatalog("bin", Configuration.PluginBlacklist.TypeNames());
+            var directoryCatalog = new BlacklistedSafeDirectoryCatalog(Configuration.PluginDirectories.DirectoryNames, Configuration.PluginBlacklist.TypeNames());
             var container = new CompositionContainer(directoryCatalog);
 
             container.ComposeParts(this, RequestValidator);


### PR DESCRIPTION
My template application is not using hard references for Glimpse or other web.config injected DLLs.  Rather, I add all dependent DLLs that I'm not referencing through code into ~/lib and I have web.config setup with a private probing path:

  <runtime>
    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
      <probing privatePath="lib" />
    </assemblyBinding>
   </runtime>

Glimpse is using MEF but is hard coded to pull the DLLs out of ~/bin, so I added the necessary configuration and changes to the module and plumbing code within Glimpse.Core.Dll to allow me to specify a set of plugin directories.  Hopefully you find this useful.
