### PR TITLE
Fix for issue #179 (slow CSharpSanitizer)

### DIFF
--- a/source/Glimpse.Core/Glimpse.Core.csproj
+++ b/source/Glimpse.Core/Glimpse.Core.csproj
@@ -155,6 +155,7 @@
     </Content>
     <Content Include="Scripts\glimpse.min.js" />
     <Content Include="Scripts\glimpse.render.engine.master.js" />
+    <Compile Include="Sanitizer\CSharpTypenameConverter.cs" />
     <Compile Include="Validator\ContentTypeValidator.cs" />
     <Compile Include="Validator\GlimpseModeValidator.cs" />
     <Compile Include="Validator\GlimpseRequestValidator.cs" />

--- a/source/Glimpse.Core/Plumbing/GlimpseSerializer.cs
+++ b/source/Glimpse.Core/Plumbing/GlimpseSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Glimpse.Core.Extensibility;
+using Glimpse.Core.Sanitizer;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -23,6 +24,7 @@ namespace Glimpse.Core.Plumbing
             };
 
             Settings.Converters.Add(new JavaScriptDateTimeConverter());
+            Settings.Converters.Add(new CSharpTypenameConverter());
 
             DefaultFormatting = Formatting.None;
         }

--- a/source/Glimpse.Core/Sanitizer/CSharpSanitizer.cs
+++ b/source/Glimpse.Core/Sanitizer/CSharpSanitizer.cs
@@ -8,24 +8,6 @@ namespace Glimpse.Core.Sanitizer
     {
         public string Sanitize(string json)
         {
-            json = FixGenerics(json); //Replace '`1[]' for generics    
-            json = Regex.Replace(json, @"(?<=System\.Nullable<.+)>(?= )", @"?"); //Add '?' for nullable types
-            json = Regex.Replace(json, @"System.Nullable<", @""); //Add '?' for nullable types
-            json = json.Replace("System.Boolean", "bool"); //Convert CLR type names to c# keywords
-            json = json.Replace("System.Byte", "byte");
-            json = json.Replace("System.SByte", "sbyte");
-            json = json.Replace("System.Char", "char");
-            json = json.Replace("System.Decimal", "decimal");
-            json = json.Replace("System.Double", "double");
-            json = json.Replace("System.Single", "float");
-            json = json.Replace("System.Int32", "int");
-            json = json.Replace("System.UInt32", "uint");
-            json = json.Replace("System.Int64", "long");
-            json = json.Replace("System.UInt64", "ulong");
-            json = json.Replace("System.Object", "object");
-            json = json.Replace("System.Int16", "short");
-            json = json.Replace("System.UInt16", "ushort");
-            json = json.Replace("System.String", "string");
             json = json.Replace("-2147483648", "\"int.MinValue\""); //Convert min ints
             json = json.Replace("2147483647", "\"int.MaxValue\""); //Convert max ints
 
@@ -44,18 +26,6 @@ namespace Glimpse.Core.Sanitizer
                 }
             }
 
-            return json;
-        }
-
-        private static readonly Regex GenericRegex = new Regex(@"\`[0-9]+\[([^\s^:^;^""]+)\]", RegexOptions.Compiled);
-        private static string FixGenerics(string json)
-        {
-            var i = 0;
-            while (GenericRegex.IsMatch(json) && i < 10)
-            {
-                json = GenericRegex.Replace(json, @"<$1>");
-                i++;
-            }
             return json;
         }
     }

--- a/source/Glimpse.Core/Sanitizer/CSharpTypenameConverter.cs
+++ b/source/Glimpse.Core/Sanitizer/CSharpTypenameConverter.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Glimpse.Core.Sanitizer
+{
+    public class CSharpTypenameConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return (typeof(Type).IsAssignableFrom(objectType));
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteValue(GetCSharpname((Type)value));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        private string GetCSharpname(Type type)
+        {
+            var typename = new StringBuilder();
+            GetCSharpname(type, typename);
+            return typename.ToString();
+        }
+
+        private void GetCSharpname(Type type, StringBuilder output)
+        {
+            bool useFullName = false;
+            bool aliasForPrimitives = true;
+
+            if (type.IsArray)
+            {
+                GetCSharpname(type.GetElementType(), output);
+                output.Append("[]");
+            }
+            else if (!type.IsGenericType)
+            {
+                if (aliasForPrimitives && primitiveTypes.ContainsKey(type))
+                {
+                    output.Append(primitiveTypes[type]);
+                }
+                else if (useFullName)
+                {
+                    output.Append(type.FullName);
+                }
+                else
+                {
+                    output.Append(type.Name);
+                }
+            }
+            else if (type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                GetCSharpname(type.GetGenericArguments().First(), output);
+                output.Append("?");
+            }
+            else
+            {
+                var genericBaseType = type.GetGenericTypeDefinition();
+                var genericName = useFullName ? genericBaseType.FullName : genericBaseType.Name;
+                output.Append(genericName, 0, genericName.LastIndexOf('`'));
+                output.Append("<");
+
+                var genericArguments = type.GetGenericArguments();
+                for (int i = 0; i < genericArguments.Length; i++)
+                {
+                    if (i > 0) output.Append(", ");
+                    GetCSharpname(genericArguments[i], output);
+                }
+
+                output.Append(">");
+                return;
+            }
+        }
+
+        private readonly static Dictionary<Type, string> primitiveTypes =
+            new Dictionary<Type, string>
+            {
+                {typeof(object), "object"},
+                {typeof(string), "string"},
+                {typeof(bool), "bool"},
+                {typeof(byte), "byte"},
+                {typeof(short), "short"},
+                {typeof(int), "int"},
+                {typeof(long), "long"},
+                {typeof(sbyte), "sbyte"},
+                {typeof(ushort), "ushort"},
+                {typeof(uint), "uint"},
+                {typeof(ulong), "ulong"},
+                {typeof(decimal), "decimal"},
+                {typeof(float), "float"},
+                {typeof(double), "double"}
+            };
+    }
+}


### PR DESCRIPTION
Move typename rewriting from CSharpSanitizer to CSharpTypenameConverter

Speed up typename rewriting by implementing a custom JsonConverter.
This allows us to write the right name directly to json instead of
rewriting it afterwards. Supports complex generic types.
