### PR TITLE
Fix ReflectionDiscoverableCollection locking files

### DIFF
--- a/source/Glimpse.Core/Framework/ReflectionDiscoverableCollection.cs
+++ b/source/Glimpse.Core/Framework/ReflectionDiscoverableCollection.cs
@@ -34,12 +34,12 @@ namespace Glimpse.Core.Framework
         {
             get
             {
-                return discoveryLocation ?? (discoveryLocation = AppDomain.CurrentDomain.BaseDirectory);
+                return discoveryLocation ?? (discoveryLocation = BaseDirectory);
             }
 
-            set
-            {
-                var result = Path.IsPathRooted(value) ? value : Path.Combine(AppDomain.CurrentDomain.BaseDirectory, value);
+            set {
+                // If this isn't an absolute path then root it with the AppDomain's base directory
+                var result = Path.IsPathRooted(value) ? value : Path.Combine(BaseDirectory, value);
 
                 if (!Directory.Exists(result))
                 {
@@ -47,6 +47,16 @@ namespace Glimpse.Core.Framework
                 }
                 
                 discoveryLocation = result;
+            }
+        }
+
+        /// Get the directory of the application, if the AppDomain is shadow copied, use the shadow directory
+        static string BaseDirectory {
+            get {
+                var setupInfo = AppDomain.CurrentDomain.SetupInformation;
+                return string.Equals(setupInfo.ShadowCopyFiles, "true", StringComparison.OrdinalIgnoreCase)
+                           ? Path.Combine(setupInfo.CachePath, setupInfo.ApplicationName)
+                           : AppDomain.CurrentDomain.BaseDirectory;
             }
         }
 
@@ -121,10 +131,8 @@ namespace Glimpse.Core.Framework
 
             foreach (var file in Directory.GetFiles(DiscoveryLocation, "*.dll", SearchOption.AllDirectories))
             {
-                Assembly assembly;
-                try
-                {
-                    assembly = Assembly.LoadFrom(file);
+                try {
+                    Assembly assembly = Assembly.LoadFrom(file);
                     Type[] allTypes;
 
                     // GetTypes potentially throws and exception. Defensive coding as per http://haacked.com/archive/2012/07/23/get-all-types-in-an-assembly.aspx


### PR DESCRIPTION
When ReflectionDiscoverableCollection loads assemblies to discover types it locks the assemblies.

This causes issues in ASP.NET applications because it was loading the assemblies from the BaseDirectory of the appdomain and not from the shadow copy directory being used by the ASP.NET application.
