### PR TITLE
Fix #319 - Allow FileResource to be used outside of Glimpse.Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ _ReSharper.*
 *.rptproj.user
 *.db
 *.ncrunchsolution
+*.ncrunchproject
 *.user
 *.log
 /Glimpse.All.crunchsolution.local.xml

--- a/source/Glimpse.Core/Resource/FileResource.cs
+++ b/source/Glimpse.Core/Resource/FileResource.cs
@@ -79,8 +79,11 @@ namespace Glimpse.Core.Resource
                 throw new ArgumentNullException("context");
             }
 
-            var assembly = Assembly.GetExecutingAssembly();
-             
+            var assembly = GetResourcesAssembly();
+            if (assembly == null) {
+                return new StatusCodeResourceResult(404, string.Format("Could not locate assembly for resource with ResourceName '{0}'.", ResourceName));
+            }
+ 
             using (var resourceStream = assembly.GetManifestResourceStream(ResourceName))
             {
                 if (resourceStream != null)
@@ -93,6 +96,14 @@ namespace Glimpse.Core.Resource
             }
 
             return new StatusCodeResourceResult(404, string.Format("Could not locate file with ResourceName '{0}'.", ResourceName));
-        } 
+        }
+        
+        /// <summary>
+        /// Gets the assembly in which the resource is embedded
+        /// </summary>
+        /// <returns>Assembly to get resource stream from</returns>
+        protected virtual Assembly GetResourcesAssembly() {
+            return GetType().Assembly;
+        }
     }
 }

--- a/source/Glimpse.Test.Core/Glimpse.Test.Core.csproj
+++ b/source/Glimpse.Test.Core/Glimpse.Test.Core.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Resource\ClientShould.cs" />
     <Compile Include="Resource\ConfigurationShould.cs" />
     <Compile Include="Resource\DataShould.cs" />
+    <Compile Include="Resource\FileResourceShould.cs" />
     <Compile Include="Resource\HistoryResourceShould.cs" />
     <Compile Include="Resource\MetadataShould.cs" />
     <Compile Include="Resource\PopupResourceShould.cs" />
@@ -208,6 +209,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="BadData\NotReallyA.dll" />
+    <EmbeddedResource Include="Resource\FileResourceTester.js" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/source/Glimpse.Test.Core/Resource/FileResourceTester.js
+++ b/source/Glimpse.Test.Core/Resource/FileResourceTester.js
@@ -1,0 +1,1 @@
+﻿alert('FileResourceTester');


### PR DESCRIPTION
Use `GetType().Assembly` in FileResource to get assembly of subtype.
