### PR TITLE
Tracking of similar SQL queries (#323)

### DIFF
--- a/source/Glimpse.Ado/Glimpse.Ado.csproj
+++ b/source/Glimpse.Ado/Glimpse.Ado.csproj
@@ -87,6 +87,10 @@
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
     </Compile>
+    <Compile Include="SimilarQueries\GappedStringComparer.cs" />
+    <Compile Include="SimilarQueries\SimilarQueryProvider.cs" />
+    <Compile Include="SimilarQueries\StringSimilarity.cs" />
+    <Compile Include="SimilarQueries\SuffixTree.cs" />
     <Compile Include="Tab\Sql.cs" />
     <Compile Include="Tab\Support\CommandSanitizer.cs" />
     <Compile Include="Tab\Support\CommandParameterParser.cs" />

--- a/source/Glimpse.Ado/Model/CommandMetadata.cs
+++ b/source/Glimpse.Ado/Model/CommandMetadata.cs
@@ -29,6 +29,7 @@ namespace Glimpse.Ado.Model
         public int ExecutionIndex { get; set; }
         public bool HasTransaction { get; set; }
         public bool IsDuplicate { get; set; }
+        public bool IsSimilar { get; set; }
          
         /// <summary>
         /// Gets or sets the head transaction. Set when the command 
@@ -43,5 +44,6 @@ namespace Glimpse.Ado.Model
         /// </summary>
         /// <value>The tail transaction.</value>
         public TransactionMetadata TailTransaction { get; set; }
+
     }
 }

--- a/source/Glimpse.Ado/SimilarQueries/GappedStringComparer.cs
+++ b/source/Glimpse.Ado/SimilarQueries/GappedStringComparer.cs
@@ -1,0 +1,222 @@
+﻿using System;
+
+namespace Glimpse.Ado.SimilarQueries
+{
+    /// <summary>
+    /// Compares pairs of strings based on a common seed which is known to match both, taking into account
+    /// potential gaps in the data (for which an alignment score penality is applied when they are opened and as they continue)
+    /// </summary>
+    public static class GappedStringComparer
+    {
+        /// <summary>
+        /// Calculate a modified percentage similarity score between two strings which have a known common substring.
+        /// Accommodates potential gaps in the data, which result in a penalty to the alignment score when they are opened and extended.
+        /// Matching will be aborted if many gaps or large gaps are found.
+        /// </summary>
+        /// <param name="firstString">The first string to compare</param>
+        /// <param name="secondString">The second string to compare</param>
+        /// <param name="substringSeed">A string known to be contained in both</param>
+        /// <returns>A value from 0 (no shared characters) to 1 (identical)</returns>
+        public static double StringSimilarity(string firstString, string secondString, string substringSeed)
+        {
+            var firstStringWindowStart = firstString.LastIndexOf(substringSeed, System.StringComparison.Ordinal);
+            var secondStringWindowStart = secondString.LastIndexOf(substringSeed, System.StringComparison.Ordinal);
+            var windowSize = substringSeed.Length;
+
+            var firstStringState = new StringState(firstString.ToCharArray(), firstStringWindowStart);
+            var secondStringState = new StringState(secondString.ToCharArray(), secondStringWindowStart);
+            var strings = new StringComparison(firstStringState, secondStringState, windowSize);
+
+            return strings.GetSimilarityScore();
+        }
+
+        /// <summary>
+        /// Maintains the overall state of the comparison between a pair of strings
+        /// </summary>
+        private class StringComparison
+        {
+            private StringState First { get; set; }
+            private StringState Second { get; set; }
+            private int Window { get; set; }
+            private double score;
+
+            public StringComparison(StringState first, StringState second, int initialWindowSize)
+            {
+                First = first;
+                Second = second;
+                Window = initialWindowSize;
+                CurrentScore = initialWindowSize;
+            }
+
+            /// <summary>
+            /// The current working alignment score for this pair
+            /// </summary>
+            private double CurrentScore
+            {
+                get { return score; }
+
+                set
+                {
+                    score = value;
+                    if (score > MaxScore) MaxScore = score;
+                }
+            }
+
+            /// <summary>
+            /// The maximum alignment score for this pair
+            /// </summary>
+            private double MaxScore { get; set; }
+
+            /// <summary>
+            /// Calculates a modified percentage similarity score for the two strings
+            /// </summary>
+            /// <returns>A value from 0 to 1, where 0 = no shared characters and 1 = strings are identical</returns>
+            public double GetSimilarityScore()
+            {
+                if (First.Start < 0 || Second.Start < 0) return 0;
+
+                // Extend left
+                while (First.Start - 1 >= 0 && Second.Start - 1 >= 0 && CurrentScore > 0)
+                {
+                    if (First.Characters[First.Start - 1] == Second.Characters[Second.Start - 1])
+                    {
+                        ApplyMatch(false);
+                    }
+                    else
+                    {
+                        if (!TryInsertGap(false)) break;
+                    }
+                }
+
+                CurrentScore = MaxScore;
+
+                // Extend right
+                while (First.Start + First.Gap + Window + 1 < First.Characters.Length
+                       && Second.Start + Second.Gap + Window + 1 < Second.Characters.Length
+                       && CurrentScore > 0)
+                {
+                    if (First.Characters[First.Start + Window + First.Gap + 1] ==
+                        Second.Characters[Second.Start + Window + Second.Gap + 1])
+                    {
+                        ApplyMatch(true);
+                    }
+                    else
+                    {
+                        if (!TryInsertGap(true)) break;
+                    }
+                }
+
+                return MaxScore / Math.Max(First.Characters.Length, Second.Characters.Length);
+            }
+
+            /// <summary>
+            /// Increments the score and moves the position on
+            /// </summary>
+            /// <param name="forward">Whether to move forwards (true) or backwards (false)</param>
+            private void ApplyMatch(bool forward)
+            {
+                CurrentScore++;
+                Window++;
+
+                if (!forward)
+                {
+                    First.Start--;
+                    Second.Start--;
+                }
+            }
+
+            /// <summary>
+            /// Attempts to insert a gap in the comparison in the specified direction
+            /// </summary>
+            /// <param name="forward">Whether to search forwards (true) or backwards (false)</param>
+            /// <returns>True if a gap was added, or false if no match was found</returns>
+            private bool TryInsertGap(bool forward)
+            {
+                var modifier = forward ? 1 + Window : -1;
+                var firstStringIndex = First.Start + modifier;
+                var secondStringIndex = Second.Start + modifier;
+
+                if (forward)
+                {
+                    firstStringIndex += First.Gap;
+                    secondStringIndex += Second.Gap;
+                }
+
+                var shortestGapFirstString = GapSize(First.Characters, firstStringIndex, Second.Characters[secondStringIndex], forward);
+                var shortestGapSecondString = GapSize(Second.Characters, secondStringIndex, First.Characters[firstStringIndex], forward);
+
+                if (shortestGapFirstString == -1 && shortestGapSecondString == -1) return false;
+
+                if (shortestGapFirstString > shortestGapSecondString)
+                {
+                    ApplyGap(First, shortestGapFirstString, forward);
+                }
+                else
+                {
+                    ApplyGap(Second, shortestGapSecondString, forward);
+                }
+
+                return true;
+            }
+
+            /// <summary>
+            /// Applies a gap to a particular string in the comparison
+            /// </summary>
+            /// <param name="targetString">The string to apply the gap to</param>
+            /// <param name="gap">The size of the gap to add</param>
+            /// <param name="forward">Whether to search forwards (true) or backwards (false)</param>
+            private void ApplyGap(StringState targetString, int gap, bool forward)
+            {
+                const double openGapPenalty = 1;
+                const double continueGapPenalty = 0.5;
+
+                CurrentScore -= openGapPenalty;
+
+                if (!forward)
+                {
+                    targetString.Start -= gap;
+                }
+
+                targetString.Gap += gap;
+                CurrentScore -= continueGapPenalty * (gap - 1);
+            }
+
+            /// <summary>
+            /// Returns the shortest distance between a start point in a character array
+            /// and the previous or next character in the array that matches another character,
+            /// or -1 if it cannot be found
+            /// </summary>
+            /// <param name="targetCharacters">The character array to search</param>
+            /// <param name="startPoint">The starting index in the array</param>
+            /// <param name="lookFor">The character to find</param>
+            /// <param name="forward">Whether to search forwards (true) or backwards (false)</param>
+            /// <returns>The number of characters before a match is found, or -1</returns>
+            private static int GapSize(char[] targetCharacters, int startPoint, char lookFor, bool forward)
+            {
+                for (int index = startPoint; index >= 0 && index < targetCharacters.Length; index += (forward) ? 1 : -1)
+                {
+                    if (targetCharacters[index] == lookFor) return Math.Abs(startPoint - index);
+                }
+
+                return -1;
+            }
+        }
+
+        /// <summary>
+        /// Maintains state for a specific string in the comparison
+        /// </summary>
+        private class StringState
+        {
+            public char[] Characters { get; private set; }
+            public int Start { get; set; }
+            public int Gap { get; set; }
+
+            public StringState(char[] characters, int startPosition)
+            {
+                Characters = characters;
+                Start = startPosition;
+                Gap = 0;
+            }
+        }
+    }
+}

--- a/source/Glimpse.Ado/SimilarQueries/SimilarQueryProvider.cs
+++ b/source/Glimpse.Ado/SimilarQueries/SimilarQueryProvider.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+
+namespace Glimpse.Ado.SimilarQueries
+{
+    /// <summary>
+    /// Checks whether a given query is similar to any of the queries that have been previously added
+    /// </summary>
+    public class SimilarQueryProvider
+    {
+        /// <summary>
+        /// The string similarity threshold above which two queries are considered similar
+        /// </summary>
+        private const double similarityThreshold = 0.5;
+
+        private readonly HashSet<string> queries; 
+        private readonly SuffixTree tree;
+
+        public SimilarQueryProvider()
+        {
+            queries = new HashSet<string>();
+            tree = new SuffixTree();
+        }
+
+        /// <summary>
+        /// Adds a new query and returns a similarity score from 0 to 1
+        /// </summary>
+        /// <param name="query">The new query string to add</param>
+        /// <returns>True if </returns>
+        public StringSimilarity AddPotentiallySimilarQuery(string query)
+        {
+            query = query.ToLowerInvariant();
+
+            if (queries.Contains(query))
+            {
+                return StringSimilarity.Identical;
+            }
+
+            var similarStringFound = SimilarStringInTree(query);
+
+            queries.Add(query);
+            tree.AddString(query);
+
+            return similarStringFound ? StringSimilarity.Similar : StringSimilarity.None;
+        }
+
+        private bool SimilarStringInTree(string query)
+        {
+            var checkedMatches = new HashSet<string>();
+
+            for (int startCharacter = 0; startCharacter + 10 < query.Length; startCharacter++)
+            {
+                var substring = query.Substring(startCharacter, 10);
+                var matches = tree.ContainedIn(substring);
+
+                foreach (var match in matches)
+                {
+                    if (checkedMatches.Contains(match)) continue;
+
+                    if (GappedStringComparer.StringSimilarity(query, match, substring) > similarityThreshold) return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/source/Glimpse.Ado/SimilarQueries/StringSimilarity.cs
+++ b/source/Glimpse.Ado/SimilarQueries/StringSimilarity.cs
@@ -1,0 +1,9 @@
+﻿namespace Glimpse.Ado.SimilarQueries
+{
+    public enum StringSimilarity
+    {
+        None,
+        Similar,
+        Identical
+    }
+}

--- a/source/Glimpse.Ado/SimilarQueries/SuffixTree.cs
+++ b/source/Glimpse.Ado/SimilarQueries/SuffixTree.cs
@@ -1,0 +1,231 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Glimpse.Ado.SimilarQueries
+{
+    /// <summary>
+    /// A simple (naive) implementation of a generalised suffix tree.
+    /// This algorithm is simple but is quadratic with respect to construction and memory.
+    /// It should be switched for Ukkonen's algorithm, which is O(n).
+    /// </summary>
+    public class SuffixTree
+    {
+        public Node rootNode { get; set; }
+
+        public SuffixTree()
+        {
+            rootNode = new Node(new char[0]);
+        }
+
+        /// <summary>
+        /// Adds a new string to the suffix tree
+        /// </summary>
+        /// <param name="str">The string to add</param>
+        public void AddString(string str)
+        {
+            str = string.Intern(str);
+            var wordCharacters = str.ToCharArray();
+
+            for (int startChar = 0; startChar < str.Length; startChar++)
+            {
+                var searchResult = SearchTree(wordCharacters, startChar);
+                var currentNode = searchResult.Node;
+
+                if (searchResult.FurthestMatchedIntoNode < searchResult.Node.Contents.Length)
+                {
+                    currentNode.SplitNode(searchResult.FurthestMatchedIntoNode);
+                }
+
+                if (searchResult.FinalCharacterIndex < wordCharacters.Length)
+                {
+                    var newNode = new Node(wordCharacters.Skip(searchResult.FinalCharacterIndex).ToArray());
+                    currentNode.AddChild(newNode);
+                    currentNode = newNode;
+                }
+
+                currentNode.AddTerminates(str);
+            }
+        }
+
+        /// <summary>
+        /// Finds the strings in the tree which contain a given string
+        /// </summary>
+        /// <param name="str">The string to search the tree with</param>
+        /// <returns>The strings </returns>
+        public IEnumerable<string> ContainedIn(string str)
+        {
+            var wordCharacters = str.ToCharArray();
+
+            var searchResult = SearchTree(wordCharacters, 0);
+
+            if (!searchResult.SuffixIsInTree) return Enumerable.Empty<string>();
+
+            return GetDescendantTerminatedStrings(searchResult.Node);
+        }
+
+        /// <summary>
+        /// Aggregates all the strings which are terminated in descendants of a given node
+        /// </summary>
+        /// <param name="startNode">The node to start at</param>
+        /// <returns>All the strings which are terminated in descendants of a given node</returns>
+        private static IEnumerable<string> GetDescendantTerminatedStrings(Node startNode)
+        {
+            var childNodesToProcess = new Queue<Node>();
+            var strings = new HashSet<string>();
+
+            childNodesToProcess.Enqueue(startNode);
+
+            while (childNodesToProcess.Count > 0)
+            {
+                var currentNode = childNodesToProcess.Dequeue();
+
+                foreach (var terminatedString in currentNode.Terminates)
+                {
+                    strings.Add(terminatedString);
+                }
+
+                foreach (var child in currentNode.Children)
+                {
+                    childNodesToProcess.Enqueue(child);
+                }
+            }
+
+            return strings;
+        }
+
+        /// <summary>
+        /// Searches the suffix tree to find the best match for a character array
+        /// </summary>
+        /// <param name="characters">The character array to base the search on</param>
+        /// <param name="startCharIndex">The character index to start at through the array</param>
+        /// <returns>A TreeSearchResult containing the results of the search</returns>
+        private TreeSearchResult SearchTree(char[] characters, int startCharIndex)
+        {
+            Node currentNode;
+            Node nextNode = rootNode;
+            int currentNodeContentsIndex;
+            var currentCharIndex = startCharIndex;
+
+            do
+            {
+                currentNode = nextNode;
+                nextNode = null;
+
+                currentNodeContentsIndex = 1;
+                while (currentNodeContentsIndex < currentNode.Contents.Length
+                       && currentCharIndex < characters.Length
+                       && currentNode.Contents[currentNodeContentsIndex] == characters[currentCharIndex])
+                {
+                    currentNodeContentsIndex++;
+                    currentCharIndex++;
+                }
+
+                if (currentCharIndex + 1 > characters.Length) break;
+
+                foreach (var child in currentNode.Children)
+                {
+                    if (child.Contents[0] == characters[currentCharIndex])
+                    {
+                        nextNode = child;
+                        currentCharIndex++;
+                        break;
+                    }
+                }
+            } while (nextNode != null);
+
+            return new TreeSearchResult(currentNode, currentCharIndex, currentNodeContentsIndex, (currentCharIndex >= characters.Length));
+        }
+
+        /// <summary>
+        /// Represents a node in the suffix tree, the contents of the edge that leads to it, and any strings it terminates
+        /// </summary>
+        public class Node
+        {
+            private List<Node> children = new List<Node>();
+            private HashSet<string> terminates = new HashSet<string>();
+
+            public char[] Contents { get; set; }
+            public IEnumerable<Node> Children { get { return children; } }
+            public IEnumerable<string> Terminates { get { return terminates; } }
+
+            /// <summary>
+            /// Create a new node with specified contents
+            /// </summary>
+            /// <param name="contents">The contents of this node</param>
+            public Node(char[] contents)
+            {
+                Contents = contents;
+            }
+
+            /// <summary>
+            /// Create a new node split from an existing node
+            /// </summary>
+            private Node(char[] contents, List<Node> inheritChildren, HashSet<string> inheritTerminates)
+            {
+                Contents = contents;
+                children = inheritChildren;
+                terminates = inheritTerminates;
+            }
+
+            /// <summary>
+            /// Adds a new child to the node
+            /// </summary>
+            /// <param name="node">The new child node</param>
+            public void AddChild(Node node)
+            {
+                children.Add(node);
+            }
+
+            /// <summary>
+            /// Add a string which is terminated at this node
+            /// </summary>
+            /// <param name="terminatesString">The string that terminates here</param>
+            public void AddTerminates(string terminatesString)
+            {
+                terminates.Add(terminatesString);
+            }
+
+            /// <summary>
+            /// Splits a node at a given character position
+            /// </summary>
+            /// <param name="retainedCharacters">The number of characters which should remain on the original node</param>
+            /// <returns>The new node which has been created</returns>
+            public Node SplitNode(int retainedCharacters)
+            {
+                var rest = Contents.Skip(retainedCharacters).ToArray();
+                Contents = Contents.Take(retainedCharacters).ToArray();
+
+                var newNode = new Node(rest, children, terminates);
+
+                children = new List<Node> { newNode };
+                terminates = new HashSet<string>();
+
+                return newNode;
+            }
+
+            public override string ToString()
+            {
+                return new string(Contents); // +" (" + string.Join(", ", terminates) + ")";
+            }
+        }
+
+        /// <summary>
+        /// Represents the results of a walk through the tree
+        /// </summary>
+        private class TreeSearchResult
+        {
+            public Node Node { get; private set; }
+            public int FinalCharacterIndex { get; private set; }
+            public bool SuffixIsInTree { get; private set; }
+            public int FurthestMatchedIntoNode { get; private set; }
+
+            public TreeSearchResult(Node node, int finalCharacterIndex, int furthestMatched, bool matchedToEnd)
+            {
+                Node = node;
+                FinalCharacterIndex = finalCharacterIndex;
+                FurthestMatchedIntoNode = furthestMatched;
+                SuffixIsInTree = matchedToEnd;
+            }
+        }
+    }
+}

--- a/source/Glimpse.Ado/Tab/Sql.cs
+++ b/source/Glimpse.Ado/Tab/Sql.cs
@@ -94,7 +94,7 @@ namespace Glimpse.Ado.Tab
                     //Commands
                     var records = command.RecordsAffected == null || command.RecordsAffected < 0 ? command.TotalRecords : command.RecordsAffected;
 
-                    var status = errors != null ? "error" : (command.IsDuplicate ? "warn" : string.Empty); 
+                    var status = errors != null ? "error" : (command.IsDuplicate || command.IsSimilar ? "warn" : string.Empty); 
                     commands.Add(new object[] { headTransaction, string.Format("{0}{1}", command.HasTransaction ? "\t\t\t" : "", commandCount++), sanitizer.Process(command.Command, command.Parameters), parameters, records, command.Duration, command.Offset, tailTransaction, errors, status });
                 } 
                 connections.Add(new [] { commands, connection.Duration.HasValue ? (object)connection.Duration.Value : null });


### PR DESCRIPTION
Initial prototype implementation of comparison of SQL queries in order to identify those which might be duplicating work because they contain substantially similar regions. The suffix tree used is a simple implementation and could be improved upon by using Ukkonen's algorithm. The similarity threshold has been chosen somewhat arbitrarily for this prototype.

No tests for this right now as Glimpse.Ado doesn't have a test framework yet.
