### PR TITLE
Fix for issue #346

### DIFF
--- a/source/Glimpse.Mvc3.MusicStore.Sample/web.config
+++ b/source/Glimpse.Mvc3.MusicStore.Sample/web.config
@@ -30,7 +30,18 @@
     <httpHandlers>
       <add path="glimpse.axd" verb="GET" type="Glimpse.AspNet.HttpHandler" />
     </httpHandlers>
-    <roleManager enabled="true" />
+    <roleManager enabled="true" defaultProvider="AspNetSqlRoleProvider" >
+      <providers>
+        <remove name="AspNetSqlRoleProvider"/>
+        <add name="AspNetSqlRoleProvider" type="System.Web.Security.SqlRoleProvider" connectionStringName="AspNetDb" />
+      </providers>
+    </roleManager>
+    <membership defaultProvider="AspNetSqlRoleProvider">
+      <providers>
+        <remove name="AspNetSqlRoleProvider"/>
+        <add name="AspNetSqlRoleProvider" type="System.Web.Security.SqlMembershipProvider" connectionStringName="AspNetDb" />
+      </providers>
+    </membership>
     <compilation debug="true" targetFramework="4.0">
       <assemblies>
         <add assembly="System.Web.Abstractions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
@@ -75,7 +86,7 @@
     <add name="AdventureWorksEntities" connectionString="metadata=.\AdventureWorks.csdl|.\AdventureWorks.ssdl|.\AdventureWorks.msl;provider=System.Data.SqlClient;provider connection string='Data Source=localhost;Initial Catalog=AdventureWorks;Integrated Security=True;Connection Timeout=60;multipleactiveresultsets=true'" providerName="System.Data.EntityClient" />
     <add name="MusicStoreEntities" connectionString="Data Source=|DataDirectory|MvcMusicStore.sdf" providerName="System.Data.SqlServerCe.4.0" />
     <add name="TestDatabase" connectionString="Driver={Microsoft Access Driver (*.mdb, *.accdb)};Dbq=C:\mydatabase.accdb;Locale Identifier=2057;Uid=Admin;Pwd=PwdMyLocal;" providerName="System.Data.Odbc" />
-    <add name="LocalSqlServer2" connectionString="data source=.\SQLEXPRESS;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|aspnetdb.mdf;User Instance=true" />
+    <add name="AspNetDb" connectionString="Server=(localdb)\v11.0;Integrated Security=true;AttachDbFileName=|DataDirectory|aspnetdb.mdf;" providerName="System.Data.SqlClient"/>
   </connectionStrings>
   <system.diagnostics>
     <sources>


### PR DESCRIPTION
To make sure the example can run without the need for a local SQL Express running, I've modified the web.config of the project, to make sure the **AspNetSqlRoleProvider** used by the asp.net roles and memberships, is using the aspnetdb.mdf file from the app_data folder but without the dependency on SQL Express.
