### PR TITLE
All .NET 4.0+ ADO and EF projects self initialize at app start.

### DIFF
--- a/source/Glimpse.Ado.Net40/Glimpse.Ado.Net40.csproj
+++ b/source/Glimpse.Ado.Net40/Glimpse.Ado.Net40.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Transactions" />
+    <Reference Include="System.Web" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Glimpse.Ado.Net40/Properties/AssemblyInfo.cs
+++ b/source/Glimpse.Ado.Net40/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Web;
+using Glimpse.Ado;
 using Glimpse.Core.Extensibility;
 
 [assembly: ComVisible(false)]
@@ -20,3 +22,4 @@ using Glimpse.Core.Extensibility;
 
 [assembly: InternalsVisibleTo("Glimpse.Test.Ado")]
 [assembly: NuGetPackage]
+[assembly: PreApplicationStartMethod(typeof(Initialize), "Start")]

--- a/source/Glimpse.Ado.Net45/Glimpse.Ado.Net45.csproj
+++ b/source/Glimpse.Ado.Net45/Glimpse.Ado.Net45.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Transactions" />
+    <Reference Include="System.Web" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Glimpse.Ado.Net45/Properties/AssemblyInfo.cs
+++ b/source/Glimpse.Ado.Net45/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Web;
+using Glimpse.Ado;
 using Glimpse.Core.Extensibility;
 
 [assembly: ComVisible(false)]
@@ -20,3 +22,4 @@ using Glimpse.Core.Extensibility;
 
 [assembly: InternalsVisibleTo("Glimpse.Test.Ado")]
 [assembly: NuGetPackage]
+[assembly: PreApplicationStartMethod(typeof(Initialize), "Start")]

--- a/source/Glimpse.Ado/Initialize.cs
+++ b/source/Glimpse.Ado/Initialize.cs
@@ -4,9 +4,15 @@ namespace Glimpse.Ado
 {
     public static class Initialize
     {
-        public static void Ado(this Glimpse.Core.Setting.Initializer initializer)
+        public static void Start()
         {
             AdoExecutionBlock.Instance.Execute();
+        }
+
+        /// <remarks>For use with .NET 3.5</remarks>
+        public static void Ado(this Glimpse.Core.Setting.Initializer initializer)
+        {
+            Start();
         }
     }
 }

--- a/source/Glimpse.EF/Initialize.cs
+++ b/source/Glimpse.EF/Initialize.cs
@@ -4,8 +4,8 @@ namespace Glimpse.EF
 {
     public static class Initialize
     {
-        public static void EF(this Glimpse.Core.Setting.Initializer initializer)
-        { 
+        public static void Start()
+        {
             EntityFrameworkExecutionBlock.Instance.Execute();
         }
     }

--- a/source/Glimpse.EF43.Net40/Glimpse.EF43.Net40.csproj
+++ b/source/Glimpse.EF43.Net40/Glimpse.EF43.Net40.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Glimpse.EF\**\*.cs" Exclude="..\Glimpse.EF\Properties\AssemblyInfo.cs">

--- a/source/Glimpse.EF43.Net40/Properties/AssemblyInfo.cs
+++ b/source/Glimpse.EF43.Net40/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Web;
 using Glimpse.Core.Extensibility;
+using Glimpse.EF;
 
 [assembly: ComVisible(false)]
 [assembly: Guid("2151cc9c-dec9-419b-851a-da5aaf694c95")]
@@ -20,3 +22,4 @@ using Glimpse.Core.Extensibility;
 
 [assembly: InternalsVisibleTo("Glimpse.Test.Ado")]
 [assembly: NuGetPackage]
+[assembly: PreApplicationStartMethod(typeof(Initialize), "Start")]

--- a/source/Glimpse.EF5.Net40/Glimpse.EF5.Net40.csproj
+++ b/source/Glimpse.EF5.Net40/Glimpse.EF5.Net40.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Glimpse.EF\**\*.cs" Exclude="..\Glimpse.EF\Properties\AssemblyInfo.cs">

--- a/source/Glimpse.EF5.Net40/Properties/AssemblyInfo.cs
+++ b/source/Glimpse.EF5.Net40/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Web;
 using Glimpse.Core.Extensibility;
+using Glimpse.EF;
 
 [assembly: ComVisible(false)]
 [assembly: Guid("8BAAD0C1-E44B-4E1B-9206-A1D8B9CD4870")]
@@ -20,3 +22,4 @@ using Glimpse.Core.Extensibility;
 
 [assembly: InternalsVisibleTo("Glimpse.Test.EF")]
 [assembly: NuGetPackage]
+[assembly: PreApplicationStartMethod(typeof(Initialize), "Start")]

--- a/source/Glimpse.EF5.Net45/Glimpse.EF5.Net45.csproj
+++ b/source/Glimpse.EF5.Net45/Glimpse.EF5.Net45.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Glimpse.EF\**\*.cs" Exclude="..\Glimpse.EF\Properties\AssemblyInfo.cs">

--- a/source/Glimpse.EF5.Net45/Properties/AssemblyInfo.cs
+++ b/source/Glimpse.EF5.Net45/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Web;
 using Glimpse.Core.Extensibility;
+using Glimpse.EF;
 
 [assembly: ComVisible(false)]
 [assembly: Guid("9A9DDFC7-B342-4E2E-99D6-2657AB8E3627")]
@@ -20,3 +22,4 @@ using Glimpse.Core.Extensibility;
 
 [assembly: InternalsVisibleTo("Glimpse.Test.EF")]
 [assembly: NuGetPackage]
+[assembly: PreApplicationStartMethod(typeof(Initialize), "Start")]

--- a/source/Glimpse.EF6.Net40/Glimpse.EF6.Net40.csproj
+++ b/source/Glimpse.EF6.Net40/Glimpse.EF6.Net40.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Web" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Glimpse.EF6.Net40/Properties/AssemblyInfo.cs
+++ b/source/Glimpse.EF6.Net40/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Web;
 using Glimpse.Core.Extensibility;
+using Glimpse.EF;
 
 [assembly: ComVisible(false)]
 [assembly: Guid("1C1FABFD-768A-4E03-88DD-14E04F6B4DD8")]
@@ -20,3 +22,4 @@ using Glimpse.Core.Extensibility;
 
 [assembly: InternalsVisibleTo("Glimpse.Test.EF")]
 [assembly: NuGetPackage]
+[assembly: PreApplicationStartMethod(typeof(Initialize), "Start")]

--- a/source/Glimpse.EF6.Net45/Glimpse.EF6.Net45.csproj
+++ b/source/Glimpse.EF6.Net45/Glimpse.EF6.Net45.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Web" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Glimpse.EF6.Net45/Properties/AssemblyInfo.cs
+++ b/source/Glimpse.EF6.Net45/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Web;
 using Glimpse.Core.Extensibility;
+using Glimpse.EF;
 
 [assembly: ComVisible(false)]
 [assembly: Guid("6F3F9D55-2BE0-47E8-83D2-0F488504CF4A")]
@@ -20,3 +22,4 @@ using Glimpse.Core.Extensibility;
 
 [assembly: InternalsVisibleTo("Glimpse.Test.EF")]
 [assembly: NuGetPackage]
+[assembly: PreApplicationStartMethod(typeof(Initialize), "Start")]

--- a/source/Glimpse.Mvc4.MusicStore.Sample/Global.asax.cs
+++ b/source/Glimpse.Mvc4.MusicStore.Sample/Global.asax.cs
@@ -18,9 +18,6 @@ namespace MvcMusicStore
     {
         protected void Application_Start()
         {
-            Glimpse.Settings.Initialize.Ado();
-            Glimpse.Settings.Initialize.EF();
-
             AreaRegistration.RegisterAllAreas();
 
             WebApiConfig.Register(GlobalConfiguration.Configuration);


### PR DESCRIPTION
Alternate solution that uses the builtin `PreApplicationStartMethod` for https://github.com/Glimpse/Glimpse/issues/321.
