### PR TITLE
Issue #400 - Added null check to glimpse.hud.js > processContentType function

### DIFF
--- a/source/Glimpse.JavaScript/glimpse.hud.js
+++ b/source/Glimpse.JavaScript/glimpse.hud.js
@@ -367,7 +367,7 @@
                             }
                         },
                         processContentType = function(type) {
-                            return type.substring(0, type.indexOf(';'));
+                            return type ? type.substring(0, type.indexOf(';')) : '';
                         },
                         render = function(details, opened) {
                             process.init(structure);


### PR DESCRIPTION
Updating the HUD with an AJAX request that has not content-type set causes the following error

Uncaught TypeError: Cannot call method 'indexOf' of null 

Added a null check to return an empty string if no content-type header is set.
