### PR TITLE
Made PreBodyTagFilter more robust, Fixes issues #341 (partially) and #442 (completely)

### DIFF
--- a/source/Glimpse.AspNet/PreBodyTagFilter.cs
+++ b/source/Glimpse.AspNet/PreBodyTagFilter.cs
@@ -7,17 +7,14 @@ namespace Glimpse.AspNet
 {
     public class PreBodyTagFilter : Stream
     {
+        private const string BodyClosingTag = "</body>";
+
         public PreBodyTagFilter(string htmlSnippet, Stream outputStream, Encoding contentEncoding, ILogger logger)
         {
-#if NET35
-            HtmlSnippet = Glimpse.AspNet.Net35.Backport.Net35Backport.IsNullOrWhiteSpace(htmlSnippet) ? string.Empty : htmlSnippet + "</body>";
-#else
-            HtmlSnippet = string.IsNullOrWhiteSpace(htmlSnippet) ? string.Empty : htmlSnippet + "</body>";
-#endif
-
+            HtmlSnippet = htmlSnippet + BodyClosingTag;
             OutputStream = outputStream;
             ContentEncoding = contentEncoding;
-            BodyEnd = new Regex("</body>", RegexOptions.Compiled | RegexOptions.Multiline);
+            BodyEnd = new Regex(BodyClosingTag, RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.RightToLeft);
             Logger = logger;
         }
 
@@ -88,7 +85,7 @@ namespace Glimpse.AspNet
 
             if (BodyEnd.IsMatch(contentInBuffer))
             {
-                string bodyCloseWithScript = BodyEnd.Replace(contentInBuffer, HtmlSnippet);
+                string bodyCloseWithScript = BodyEnd.Replace(contentInBuffer, HtmlSnippet, 1);
 
                 byte[] outputBuffer = ContentEncoding.GetBytes(bodyCloseWithScript);
 

--- a/source/Glimpse.Test.AspNet/Glimpse.Test.AspNet.csproj
+++ b/source/Glimpse.Test.AspNet/Glimpse.Test.AspNet.csproj
@@ -70,6 +70,7 @@
     <Compile Include="AlternateType\RouteConstraintShould.cs" />
     <Compile Include="AlternateType\RouteProcessConstraintShould.cs" />
     <Compile Include="AspNetFrameworkProviderShould.cs" />
+    <Compile Include="PreBodyTagFilterShould.cs" />
     <Compile Include="HttpApplicationStateBaseDataAdapterShould.cs" />
     <Compile Include="HttpHandlerShould.cs" />
     <Compile Include="HttpModuleShould.cs" />

--- a/source/Glimpse.Test.AspNet/PreBodyTagFilterShould.cs
+++ b/source/Glimpse.Test.AspNet/PreBodyTagFilterShould.cs
@@ -1,0 +1,91 @@
+﻿using System.IO;
+using System.Text;
+using Glimpse.AspNet;
+using Glimpse.Core.Extensibility;
+using Moq;
+using Xunit;
+
+namespace Glimpse.Test.AspNet
+{
+    public class PreBodyTagFilterShould
+    {
+        private readonly Mock<ILogger> loggerMock;
+
+        public PreBodyTagFilterShould()
+        {
+            this.loggerMock = new Mock<ILogger>();
+        }
+
+        [Fact]
+        public void HaveReplacedTheClosingBodyTag()
+        {
+            const string htmlSnippet = "MY HTML SNIPPET";
+            const string inputToProcess = "<html><body><span>some content</span></body></html>";
+            const string expectedResult = "<html><body><span>some content</span>" + htmlSnippet + "</body></html>";
+            string result = this.ProcessInputByPreBodyTagFilter(inputToProcess, htmlSnippet);
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void HaveReplacedTheClosingBodyTagEvenWhenBodyTagIsBadlyCased()
+        {
+            const string htmlSnippet = "MY HTML SNIPPET";
+            const string inputToProcess = "<html><body><span>some content</span></BoDy></html>";
+            const string expectedResult = "<html><body><span>some content</span>" + htmlSnippet + "</body></html>";
+            string result = this.ProcessInputByPreBodyTagFilter(inputToProcess, htmlSnippet);
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void HaveWrittenWarningWhenThereIsNoClosingBodyTag()
+        {
+            this.loggerMock.Setup(m => m.Warn(null, (object[])null)).Verifiable();
+            const string inputToProcess = "<html><body>some content</html>";
+            string result = this.ProcessInputByPreBodyTagFilter(inputToProcess, "HTML SNIPPET");
+
+            this.loggerMock.Verify(
+                logger => logger.Warn(
+                            "Unable to locate '</body>' with content encoding '{0}'. Response may be compressed.",
+                            It.Is<object[]>(arguments => arguments.Length == 1 && object.Equals(arguments[0], Encoding.UTF8.EncodingName))),
+                Times.Once());
+
+            Assert.Equal(inputToProcess, result);
+        }
+
+        [Fact]
+        public void HaveOnlyReplacedTheLastClosingBodyTag()
+        {
+            const string htmlSnippet = "MY HTML SNIPPET";
+            const string inputToProcess = "<html><body><span>some content</span></body><p>some more content</p></body></html>";
+            const string expectedResult = "<html><body><span>some content</span></body><p>some more content</p>" + htmlSnippet + "</body></html>";
+            string result = this.ProcessInputByPreBodyTagFilter(inputToProcess, htmlSnippet);
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void HaveReplacedTheLastClosingBodyTagWithOnlyAnotherClosingBodyTagWhenTheHtmlSnippetIsNullOrEmpty()
+        {
+            const string inputToProcess = "<html><body><span>some content</span></body><p>some more content</p></body></html>";
+            string result = this.ProcessInputByPreBodyTagFilter(inputToProcess, null);
+            Assert.Equal(inputToProcess, result);
+
+            result = this.ProcessInputByPreBodyTagFilter(inputToProcess, string.Empty);
+            Assert.Equal(inputToProcess, result);
+        }
+
+        private string ProcessInputByPreBodyTagFilter(string inputToProcess, string htmlSnippet)
+        {
+            using (var memoryStream = new MemoryStream())
+            {
+                var preBodyTagFilter = new PreBodyTagFilter(htmlSnippet, memoryStream, Encoding.UTF8, this.loggerMock.Object);
+
+                byte[] buffer = Encoding.UTF8.GetBytes(inputToProcess);
+                preBodyTagFilter.Write(buffer, 0, buffer.Length);
+                preBodyTagFilter.Flush();
+                preBodyTagFilter.Position = 0;
+
+                return Encoding.UTF8.GetString(memoryStream.ToArray());
+            }
+        }
+    }
+}


### PR DESCRIPTION
So that it will now detect and handle accordingly the following situations:
- only 1 `</body>` tag is present (will be prefixed with snippet if needed)
- multiple `</body>` tags are present(only last want will be prefixed with snippet it needed)
- no `</body>` tags are present
- detect non standard casing of `</body>` tags (`</BODY>`,`</BoDy>`...)
