### PR TITLE
Allow resources to access form data as a parameter

### DIFF
--- a/source/Glimpse.AspNet/HttpHandler.cs
+++ b/source/Glimpse.AspNet/HttpHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Specialized;
+using System.Linq;
 using System.Web;
 using Glimpse.Core.Framework;
 
@@ -35,8 +36,22 @@ namespace Glimpse.AspNet
             }
             else
             {
-                runtime.ExecuteResource(resourceName, new ResourceParameters(queryString.AllKeys.Where(key => key != null).ToDictionary(key => key, key => queryString[key])));
+                runtime.ExecuteResource(resourceName, BuildResourceParameters(queryString, context.Request.Form));
             }
+        }
+
+        private ResourceParameters BuildResourceParameters(NameValueCollection queryString, NameValueCollection form)
+        {
+            // Process querystring
+            var parameters = queryString.AllKeys.Where(key => key != null).ToDictionary(key => key, key => queryString[key]);
+            
+            // Process form
+            foreach (var key in form.AllKeys.Where(key => !parameters.ContainsKey(key)))
+            {
+                parameters.Add(key, form[key]);
+            } 
+
+            return new ResourceParameters(parameters)
         }
     }
 }


### PR DESCRIPTION
Currently resources can only access data that is sent via the querystring. I'm working on various demos, and it would make sense that we should allow access to the form as well. 

My concern about doing this is more a semantic one. Firstly, should we allow this, or does it break the RESTful of the resources. On the surface this might be true, but when you look at use cases where the dev could be PUTing data to the server, POST makes a lot of sense.

If we do include this, my other concern is whether the GET and the POST can be merged together. There are areas in the framework that this does occur (so its not totally unprecedented) but again when it comes to semantics, should it be isolated out.

Note, if we decide to go ahead with this approach, I'll add the unit tests etc.
