### PR TITLE
Preload assemblies during Glimpse Runtime startup

### DIFF
--- a/source/Glimpse.AspNet/HttpModule.cs
+++ b/source/Glimpse.AspNet/HttpModule.cs
@@ -18,7 +18,16 @@ namespace Glimpse.AspNet
             var serviceLocator = new AspNetServiceLocator();
             Factory = new Factory(serviceLocator);
             serviceLocator.Logger = Factory.InstantiateLogger();
-            BuildManager.GetReferencedAssemblies();
+
+            try
+            {
+                BuildManager.GetReferencedAssemblies();
+                serviceLocator.Logger.Debug("Preloaded all referenced assemblies with System.Web.Compilation.BuildManager.GetReferencedAssemblies()");
+            }
+            catch (Exception exception)
+            {
+                serviceLocator.Logger.Error("Call to System.Web.Compilation.BuildManager.GetReferencedAssemblies() failed.", exception);
+            }
         }
 
         public void Init(HttpApplication httpApplication)


### PR DESCRIPTION
To solve issue #462 we needed a way to make sure that assemblies that are dynamically loaded get pre-loaded on startup, otherwise functionality available inside them wouldn't be discovered after a recycle of the application and the way ASP.NET handles restarts.

This pull request is the implementation of [a suggested solution](https://github.com/Glimpse/Glimpse/issues/462#issuecomment-21167955)
