### PR TITLE
Changed references towards glimpse.js to make solution build again

### DIFF
--- a/Glimpse.All.sln
+++ b/Glimpse.All.sln
@@ -34,8 +34,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Glimpse.AspNet.Net35", "sou
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Glimpse.Test.AspNet.Net35", "source\Glimpse.Test.AspNet.Net35\Glimpse.Test.AspNet.Net35.csproj", "{CD52E292-1514-4B09-900B-6A7E20468152}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Glimpse.JavaScript", "source\Glimpse.JavaScript\Glimpse.JavaScript.csproj", "{2C80D03B-32DC-4D52-9200-0B7598D9D1FF}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{0352975D-08B7-435E-B444-A77292D4F6E1}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
@@ -204,16 +202,6 @@ Global
 		{CD52E292-1514-4B09-900B-6A7E20468152}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{CD52E292-1514-4B09-900B-6A7E20468152}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{CD52E292-1514-4B09-900B-6A7E20468152}.Release|x86.ActiveCfg = Release|Any CPU
-		{2C80D03B-32DC-4D52-9200-0B7598D9D1FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2C80D03B-32DC-4D52-9200-0B7598D9D1FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2C80D03B-32DC-4D52-9200-0B7598D9D1FF}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{2C80D03B-32DC-4D52-9200-0B7598D9D1FF}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{2C80D03B-32DC-4D52-9200-0B7598D9D1FF}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{2C80D03B-32DC-4D52-9200-0B7598D9D1FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2C80D03B-32DC-4D52-9200-0B7598D9D1FF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2C80D03B-32DC-4D52-9200-0B7598D9D1FF}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{2C80D03B-32DC-4D52-9200-0B7598D9D1FF}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{2C80D03B-32DC-4D52-9200-0B7598D9D1FF}.Release|x86.ActiveCfg = Release|Any CPU
 		{6B8B535F-923B-4083-A5BD-31A34F5230A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6B8B535F-923B-4083-A5BD-31A34F5230A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6B8B535F-923B-4083-A5BD-31A34F5230A1}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU

--- a/source/Glimpse.Core.Net35/Glimpse.Core.Net35.csproj
+++ b/source/Glimpse.Core.Net35/Glimpse.Core.Net35.csproj
@@ -66,12 +66,11 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\Glimpse.JavaScript\glimpse.js">
+    <EmbeddedResource Include="..\Glimpse.Core\glimpse.js">
       <Link>glimpse.js</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="..\Glimpse.Core\**\*.png" />
-    <EmbeddedResource Include="..\Glimpse.Core\Resources.resx"/>
+    <EmbeddedResource Include="..\Glimpse.Core\Resources.resx" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/source/Glimpse.Core.Net40/Glimpse.Core.Net40.csproj
+++ b/source/Glimpse.Core.Net40/Glimpse.Core.Net40.csproj
@@ -68,9 +68,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\Glimpse.JavaScript\glimpse.js">
+    <EmbeddedResource Include="..\Glimpse.Core\glimpse.js">
       <Link>glimpse.js</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="..\Glimpse.Core\**\*.png" />
     <EmbeddedResource Include="..\Glimpse.Core\Resources.resx" />

--- a/source/Glimpse.Core.Net45/Glimpse.Core.Net45.csproj
+++ b/source/Glimpse.Core.Net45/Glimpse.Core.Net45.csproj
@@ -71,9 +71,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\Glimpse.JavaScript\glimpse.js">
+    <EmbeddedResource Include="..\Glimpse.Core\glimpse.js">
       <Link>glimpse.js</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="..\Glimpse.Core\**\*.png" />
     <EmbeddedResource Include="..\Glimpse.Core\Resources.resx" />

--- a/source/Glimpse.Core.Net45/NuSpec/Glimpse.nuspec
+++ b/source/Glimpse.Core.Net45/NuSpec/Glimpse.nuspec
@@ -40,7 +40,7 @@ Welterweight release for Core:
         <file src="lib\net40\*.*" target="lib\net40" />
         <file src="lib\net45\*.*" target="lib\net45" />
         <file src="..\..\Glimpse.Core\**\*.cs" target="src" />
-        <file src="..\..\Glimpse.Core\bin\Release\glimpse.js" target="src" />
+        <file src="..\..\Glimpse.Core\glimpse.js" target="src" />
         <file src="..\..\Glimpse.Core\Resources.resx" target="src" />
         <file src="..\..\Glimpse.Core\Resources.Designer.cs" target="src\Glimpse.Core" />
         <file src="..\..\Glimpse.Core.Net35\Backport\*.*" target="src\Backport" />

--- a/source/Glimpse.Core/Glimpse.Core.csproj
+++ b/source/Glimpse.Core/Glimpse.Core.csproj
@@ -288,9 +288,7 @@
     <EmbeddedResource Include="sprite.png" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="glimpse.js">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
+    <EmbeddedResource Include="glimpse.js" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />


### PR DESCRIPTION
After removing the Glimpse.Javascript project, the solution failed to build due to bad references to a glimpse.js file

Now, I'm guessing, is that since the Glimpse.Javascript project has moved into its own repository and a glimpse.js file has been added to the Glimpse.Core project, that all solution references to that file (inside NuSpec and .NET framework specific Glimpse.Core projects) should reference the glimpse.js file from the Glimpse.Core project, so that is what I've done here.

I also removed the copy to output folder, since it is an embedded resource and I think the only reason to copy it to the output folder was because the nuspec file was referencing the glimpse.js file from the release output folder?!

I also removed the reference towards the Glimpse.Javascript project from the solution, since it isn't there anymore.

Anyway, the solution builds again locally, but to make sure it is not a "it builds on my machine" situation, I'm using this pullrequest so that it gets build on the buildserver as well ;-)
