### PR TITLE
Fix race condition between message bus and subscribers

### DIFF
--- a/source/Glimpse.Core/Extensions/TabContextExtensions.cs
+++ b/source/Glimpse.Core/Extensions/TabContextExtensions.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using Glimpse.Core.Extensibility;
 
 namespace Glimpse.Core.Extensions
@@ -23,7 +22,9 @@ namespace Glimpse.Core.Extensions
 
             if (!tabStore.Contains<IList<T>>())
             {
-                return Enumerable.Empty<T>();
+                var messages = new List<T>();
+                tabStore.Set<IList<T>>(messages);
+                return messages;
             }
 
             return tabStore.Get<IList<T>>();

--- a/source/Glimpse.Test.Core/Tab/TraceShould.cs
+++ b/source/Glimpse.Test.Core/Tab/TraceShould.cs
@@ -41,8 +41,8 @@ namespace Glimpse.Test.Core.Tab
          
         [Fact]
         public void ReturnData()
-        { 
-            var model = new ITraceMessage[0];
+        {
+            var model = new List<ITraceMessage>(0);
             var dataStoreMock = new Mock<IDataStore>();
             dataStoreMock.Setup(c => c.Get(typeof(IList<ITraceMessage>).AssemblyQualifiedName)).Returns(model);
             var contextMock = new Mock<ITabContext>();
@@ -53,6 +53,6 @@ namespace Glimpse.Test.Core.Tab
 
             Assert.NotNull(result);
             Assert.Equal(model, result);
-        } 
+        }
     }
 }


### PR DESCRIPTION
Now makes list, before returning it, if it doesn't exist. Previously
returned new, empty IEnumerable, each time.
Test was making assumptions about _type_ of IEnumerable being returned.
