### PR TITLE
Made in-memory persistence store thread-safe

### DIFF
--- a/source/Glimpse.Core/Framework/ApplicationPersistenceStore.cs
+++ b/source/Glimpse.Core/Framework/ApplicationPersistenceStore.cs
@@ -17,6 +17,8 @@ namespace Glimpse.Core.Framework
         private const string PersistenceStoreKey = "__GlimpsePersistenceKey";
 
         private const int BufferSize = 25;
+        
+        private readonly object queueLock = new object();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApplicationPersistenceStore" /> class.
@@ -35,7 +37,7 @@ namespace Glimpse.Core.Framework
 
             GlimpseRequests = glimpseRequests;
         }
-        
+
         internal Queue<GlimpseRequest> GlimpseRequests { get; set; }
 
         private IDataStore DataStore { get; set; }
@@ -48,12 +50,15 @@ namespace Glimpse.Core.Framework
         /// <param name="request">The request.</param>
         public void Save(GlimpseRequest request)
         {
-            if (GlimpseRequests.Count >= BufferSize)
+            lock (queueLock)
             {
-                GlimpseRequests.Dequeue();
-            }
+                if (GlimpseRequests.Count >= BufferSize)
+                {
+                    GlimpseRequests.Dequeue();
+                }
 
-            GlimpseRequests.Enqueue(request);
+                GlimpseRequests.Enqueue(request);
+            }
         }
 
         /// <summary>
@@ -74,7 +79,10 @@ namespace Glimpse.Core.Framework
         /// </returns>
         public GlimpseRequest GetByRequestId(Guid requestId)
         {
-            return GlimpseRequests.FirstOrDefault(r => r.RequestId == requestId);
+            lock (queueLock)
+            {
+                return GlimpseRequests.FirstOrDefault(r => r.RequestId == requestId);
+            }
         }
 
         /// <summary>
@@ -92,8 +100,8 @@ namespace Glimpse.Core.Framework
             {
                 throw new ArgumentException("tabKey");
             }
-            
-            var request = GlimpseRequests.FirstOrDefault(r => r.RequestId == requestId);
+
+            var request = GetByRequestId(requestId);
 
             if (request == null || !request.TabData.ContainsKey(tabKey))
             {
@@ -112,7 +120,10 @@ namespace Glimpse.Core.Framework
         /// </returns>
         public IEnumerable<GlimpseRequest> GetByRequestParentId(Guid parentRequestId)
         {
-            return GlimpseRequests.Where(r => r.ParentRequestId == parentRequestId).ToList();
+            lock (queueLock)
+            {
+                return GlimpseRequests.Where(r => r.ParentRequestId == parentRequestId).ToList();
+            }
         }
 
         /// <summary>
@@ -124,7 +135,10 @@ namespace Glimpse.Core.Framework
         /// </returns>
         public IEnumerable<GlimpseRequest> GetTop(int count)
         {
-            return GlimpseRequests.Take(count).ToList();
+            lock (queueLock)
+            {
+                return GlimpseRequests.Take(count).ToList();
+            }
         }
 
         /// <summary>

--- a/source/Glimpse.Test.Core/Framework/ApplicationPersistenceStoreShould.cs
+++ b/source/Glimpse.Test.Core/Framework/ApplicationPersistenceStoreShould.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Glimpse.Core.Extensibility;
+using Glimpse.Core.Framework;
+using Moq;
+using Xunit;
+
+namespace Glimpse.Test.Core.Framework
+{
+    public class ApplicationPersistenceStoreShould
+    {
+        [Fact]
+        public void BeThreadSafe()
+        {
+            var sut = new ApplicationPersistenceStore(new DictionaryDataStoreAdapter(new Dictionary<string, object>()));
+
+            Action<ApplicationPersistenceStore> addingRequests = store =>
+            {
+                var glimpseRequest = new GlimpseRequest(
+                    Guid.NewGuid(),
+                    new Mock<IRequestMetadata>().Object,
+                    new Dictionary<string, TabResult>(),
+                    new Dictionary<string, TabResult>(),
+                    new TimeSpan(1000));
+
+                for (int requestCounter = 0; requestCounter < 200; requestCounter++)
+                {
+                    store.Save(glimpseRequest);
+
+                    Thread.Sleep(10);
+                }
+            };
+
+            Action<ApplicationPersistenceStore> gettingRequests = store =>
+            {
+                for (int requestCounter = 0; requestCounter < 200; requestCounter++)
+                {
+                    // gets will never by found with the given GUID, but that is not a problem, it's even a good
+                    // thing for this test, since it will enumerate the complete collection, quicker running into
+                    // threading issues while the state is being manipulated while enumerating it.
+
+                    store.GetByRequestId(Guid.NewGuid());
+                    store.GetByRequestParentId(Guid.NewGuid());
+                    store.GetByRequestIdAndTabKey(Guid.NewGuid(), "SomeUnknownTabKey");
+                    store.GetTop(10);
+
+                    Thread.Sleep(14);
+                }
+            };
+
+            var invokedDelegates = new List<Tuple<Action<ApplicationPersistenceStore>, IAsyncResult>>
+            {
+                new Tuple<Action<ApplicationPersistenceStore>, IAsyncResult>(addingRequests, addingRequests.BeginInvoke(sut, null, null)),
+                new Tuple<Action<ApplicationPersistenceStore>, IAsyncResult>(gettingRequests, gettingRequests.BeginInvoke(sut, null, null)),
+                new Tuple<Action<ApplicationPersistenceStore>, IAsyncResult>(addingRequests, addingRequests.BeginInvoke(sut, null, null)),
+                new Tuple<Action<ApplicationPersistenceStore>, IAsyncResult>(gettingRequests, gettingRequests.BeginInvoke(sut, null, null)),
+                new Tuple<Action<ApplicationPersistenceStore>, IAsyncResult>(addingRequests, addingRequests.BeginInvoke(sut, null, null)),
+                new Tuple<Action<ApplicationPersistenceStore>, IAsyncResult>(gettingRequests, gettingRequests.BeginInvoke(sut, null, null))
+            };
+
+            foreach (var invokedDelegate in invokedDelegates)
+            {
+                invokedDelegate.Item1.EndInvoke(invokedDelegate.Item2);
+            }
+        }
+    }
+}

--- a/source/Glimpse.Test.Core/Glimpse.Test.Core.csproj
+++ b/source/Glimpse.Test.Core/Glimpse.Test.Core.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Extensions\EnumExtensionsShould.cs" />
     <Compile Include="Extensions\TestingExtensions.cs" />
     <Compile Include="Framework\CastleDynamicProxyFactoryShould.cs" />
+    <Compile Include="Framework\ApplicationPersistenceStoreShould.cs" />
     <Compile Include="Framework\MessageBrokerShould.cs" />
     <Compile Include="Framework\FactoryShould.cs" />
     <Compile Include="Framework\GlimpseConfigurationShould.cs" />


### PR DESCRIPTION
As mentioned in #597 there are some issues when using the default `ApplicationPersistenceStore` from Glimpse in an environment where requests are building up quite rapidly (especially with a maximum queue size of 25 requests).

I added a loadtest disguised as a unittest that clearly illustrates the problem. If you change the lines with `lock (queueLock)` to `//lock (queueLock)` and run the test, then you'll get one of the following exceptions:

```
System.InvalidOperationException
Collection was modified after the enumerator was instantiated.

Server stack trace: 
   at System.Collections.Generic.Queue`1.Enumerator.MoveNext()
   at System.Linq.Enumerable.FirstOrDefault(IEnumerable`1 source, Func`2 predicate)
   at Glimpse.Core.Framework.ApplicationPersistenceStore.GetByRequestId(Guid requestId) in ApplicationPersistenceStore.cs
```

```
System.NullReferenceException
Object reference not set to an instance of an object.

Server stack trace: 
   at Glimpse.Core.Framework.ApplicationPersistenceStore.<>c__DisplayClass1.<GetByRequestId>b__0(GlimpseRequest r) in ApplicationPersistenceStore.cs: line 77
   at System.Linq.Enumerable.FirstOrDefault(IEnumerable`1 source, Func`2 predicate)
   at Glimpse.Core.Framework.ApplicationPersistenceStore.GetByRequestId(Guid requestId) in ApplicationPersistenceStore.cs
```

```
System.ArgumentException
Source array was not long enough. Check srcIndex and length, and the array's lower bounds.

Server stack trace: 
   at System.Array.Copy(Array sourceArray, Int32 sourceIndex, Array destinationArray, Int32 destinationIndex, Int32 length, Boolean reliable)
   at System.Collections.Generic.Queue`1.SetCapacity(Int32 capacity)
   at System.Collections.Generic.Queue`1.Enqueue(T item)
   at Glimpse.Core.Framework.ApplicationPersistenceStore.Save(GlimpseRequest request) in ApplicationPersistenceStore.cs
```

By adding locks when accessing `GlimpseRequests` the exceptions above won't occur anymore. The performance impact can be neglected and it is always better than throwing around exceptions, don't you think?

@nikmd23 Any reason why I should **not remove** the passed in `IDataStore`? The queue is put inside the store with a private key and never retrieved from the store afterwards since it is kept as a private field inside the _singleton_ instance of the `ApplicationPersistenceStore` (is created only once by the `Factory` ...). Or do you see reasons why we might end up with multiple instances of the `ApplicationPersistenceStore` all sharing the same queue? Because if that would be the case, then we need to wrap that queue so that the locking is shared as well and put that wrapped queue inside the store, or we lock on the queue instance instead of on the private `queueLock` field, but then we need to adapt the code that puts it in the store in the first place, so that that code is thread safe as well. Plenty of options to choose from, but it would make it a lot clearer afterwards
