### PR TITLE
Glimpse v2 - API for submitting messages to timeline

### DIFF
--- a/source/Glimpse.Core/Glimpse.Core.csproj
+++ b/source/Glimpse.Core/Glimpse.Core.csproj
@@ -130,6 +130,8 @@
     <Compile Include="Framework\Support\ExecutionBlockBase.cs" />
     <Compile Include="Framework\Support\IExecutionTask.cs" />
     <Compile Include="Framework\UriTemplateResourceEndpointConfiguration.cs" />
+    <Compile Include="GlimpseTimeline.cs" />
+    <Compile Include="Message\TimelineMessage.cs" />
     <Compile Include="PreBodyTagInjectionStream.cs" />
     <Compile Include="Resource\ConfigurationScriptResource.cs">
       <SubType>Code</SubType>

--- a/source/Glimpse.Core/GlimpseTimeline.cs
+++ b/source/Glimpse.Core/GlimpseTimeline.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Glimpse.Core.Extensibility;
+using Glimpse.Core.Framework;
+using Glimpse.Core.Message;
+
+namespace Glimpse.Core
+{
+    public static class GlimpseTimeline
+    {
+        public static OngoingCapture Capture(string eventName)
+        {
+            return Capture(eventName, string.Empty);
+        }
+
+        public static OngoingCapture Capture(string eventName, string eventSubText)
+        {
+            if (string.IsNullOrEmpty(eventName))
+            {
+                throw new ArgumentNullException("eventName");
+            }
+
+            if (!GlimpseRuntime.IsInitialized)
+            {
+                return OngoingCapture.Empty();
+            }
+
+            var messageBroker = GlimpseRuntime.Instance.Configuration.MessageBroker;
+            var executionTimer = GlimpseRuntime.Instance.CurrentRequestContext.CurrentExecutionTimer;
+
+            return new OngoingCapture(executionTimer, messageBroker, eventName, eventSubText);
+        }
+
+        public static void CaptureMoment(string eventName)
+        {
+            CaptureMoment(eventName, string.Empty);
+        }
+
+        public static void CaptureMoment(string eventName, string eventSubText)
+        {
+            if (string.IsNullOrEmpty(eventName))
+            {
+                throw new ArgumentNullException("eventName");
+            }
+
+            if (!GlimpseRuntime.IsInitialized)
+            {
+                return;
+            }
+
+            var messageBroker = GlimpseRuntime.Instance.Configuration.MessageBroker;
+            var executionTimer = GlimpseRuntime.Instance.CurrentRequestContext.CurrentExecutionTimer;
+
+            messageBroker.Publish(new TimelineMessage(executionTimer.Point(), eventName, eventSubText));
+        }
+
+        public class OngoingCapture : IDisposable
+        {
+            public static OngoingCapture Empty()
+            {
+                return new NullOngoingCapture();
+            }
+
+            private OngoingCapture()
+            {
+            }
+
+            public OngoingCapture(IExecutionTimer executionTimer, IMessageBroker messageBroker, string eventName, string eventSubText)
+            {
+                Offset = executionTimer.Start();
+                ExecutionTimer = executionTimer;
+                EventSubText = eventSubText;
+                MessageBroker = messageBroker;
+                EventName = eventName;
+            }
+
+            private string EventSubText { get; set; }
+
+            private string EventName { get; set; }
+
+            private TimeSpan Offset { get; set; }
+
+            private IExecutionTimer ExecutionTimer { get; set; }
+
+            private IMessageBroker MessageBroker { get; set; }
+
+            public virtual void Stop()
+            {
+                var timerResult = ExecutionTimer.Stop(Offset);
+                  
+                MessageBroker.Publish(new TimelineMessage(timerResult, EventName, EventSubText));
+            }
+
+            public void Dispose()
+            {
+                Stop();
+            }
+
+            private class NullOngoingCapture : OngoingCapture
+            {
+                public override void Stop()
+                {
+                }
+            }
+        }
+    }
+}

--- a/source/Glimpse.Core/Message/TimelineMessage.cs
+++ b/source/Glimpse.Core/Message/TimelineMessage.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Glimpse.Core.Extensibility;
+
+namespace Glimpse.Core.Message
+{
+    public class TimelineMessage : MessageBase, ITimelineMessage
+    {
+        public TimelineMessage(TimerResult timerResult, string eventName, string eventSubText)
+            : this(timerResult, eventName, eventSubText, new TimelineCategoryItem("GlimpseTimeline.Capture", "#3c454f", "#eee"))
+        {
+        }
+
+
+        public TimelineMessage(TimerResult timerResult, string eventName, string eventSubText, TimelineCategoryItem eventCategory)
+        {
+            Offset = timerResult.Offset;
+            Duration = timerResult.Duration;
+            StartTime = timerResult.StartTime;
+            EventName = eventName;
+            EventSubText = eventSubText;
+            EventCategory = eventCategory;
+        }
+
+        public TimeSpan Offset { get; set; }
+
+        public TimeSpan Duration { get; set; }
+
+        public DateTime StartTime { get; set; }
+
+        public string EventName { get; set; }
+
+        public TimelineCategoryItem EventCategory { get; set; }
+
+        public string EventSubText { get; set; }
+    }
+}

--- a/source/Glimpse.Mvc3.MusicStore.Sample/Controllers/HomeController.cs
+++ b/source/Glimpse.Mvc3.MusicStore.Sample/Controllers/HomeController.cs
@@ -9,6 +9,7 @@ using System.Transactions;
 using System.Web;
 using System.Web.Mvc;
 using Dapper;
+using Glimpse.Core;
 using MvcMusicStore.Models;
 
 namespace MvcMusicStore.Controllers
@@ -29,18 +30,26 @@ namespace MvcMusicStore.Controllers
         {
             // Get most popular albums
             var albums = GetTopSellingAlbums(5);
-            var albumCount = GetTotalAlbumns();
 
-            Trace.Write(string.Format("Total number of Albums = {0} and Albums with 'The' = {1}", albumCount.Item1, albumCount.Item2));
-            Trace.Write("Got top 5 albums");
-            Trace.TraceWarning("Test TraceWarning;");
-            Trace.IndentLevel++;
-            Trace.TraceError("Test TraceError;");
-            Trace.Write("Another trace line");
-            Trace.IndentLevel++;
-            Trace.Write("Yet another trace line");
-            Trace.IndentLevel = 0;
-            Trace.TraceInformation("Test TraceInformation;");
+            var albumCount = new Tuple<int, int>(0, 0); 
+            using (GlimpseTimeline.Capture("Lots of SQL stuff"))
+            {
+                albumCount = GetTotalAlbumns();
+            }
+
+            using (GlimpseTimeline.Capture("Trace Statement"))
+            {
+                Trace.Write(string.Format("Total number of Albums = {0} and Albums with 'The' = {1}", albumCount.Item1, albumCount.Item2));
+                Trace.Write("Got top 5 albums");
+                Trace.TraceWarning("Test TraceWarning;");
+                Trace.IndentLevel++;
+                Trace.TraceError("Test TraceError;");
+                Trace.Write("Another trace line");
+                Trace.IndentLevel++;
+                Trace.Write("Yet another trace line");
+                Trace.IndentLevel = 0;
+                Trace.TraceInformation("Test TraceInformation;");
+            }
 
             HttpContext.Session["TestObject"] = new Artist { ArtistId = 123, Name = "Test Artist" };
 


### PR DESCRIPTION
Currently, if I want to register an event, I have to somehow get an instance of the messages bus, create a custom class create own stopwatch or get a hold of the registered `Func<IExecutionTimer>` and then profile the desired code. All of this take a lot more lines of code than it should.

This should be a one liner for moment in time events or a simple using statement if its a duration event. Any solution probably should be able to be accessed statically and a null provider registered in this hook so that the code works for testing, but when my code fully runs, it uses a real provider.

As per @nikmd23:

> I've refactored the code and updated the class names. Now you can use these two entry points like so:
1. As a user, modify configuration:
   
   ``` c#
   GlimpseConfiguration.Override = config => 
   {
       // modify the configuration
   };
   ```
2. As a user, capture a timing event:
   
   ``` c#
   using(GlimpseTimeline.Capture("Some chunk of code to measure"))
   {
       // some custom user code
   }
   ```
3. As a user, capture a moment in time for the timeline:
   
   ``` c#
   GlimpseTimeline.CaptureMoment("Some event I want to mark in the timeline");
   ```
