### PR TITLE
Fix Ajax requests that are using "Bufferless input streams" 

### DIFF
--- a/source/Glimpse.AspNet/Model/RequestModel.cs
+++ b/source/Glimpse.AspNet/Model/RequestModel.cs
@@ -110,7 +110,15 @@ namespace Glimpse.AspNet.Model
         {
             if (httpRequest != null)
             {
-                var files = httpRequest.Files;
+                HttpFileCollectionBase files = null;
+
+                try
+                {
+                    files = httpRequest.Files;
+                }
+                catch (HttpException)
+                {
+                }
 
                 if (files != null)
                 {


### PR DESCRIPTION
HttpRequest.Files throws an exception if the request is read using a
bufferless input stream (this is the case for some of my WCF services
with JSON endpoint). The excpetion screws up the whole switching to that
request. Catching the error will show all other data (e.g. SQL
statements) for that request without problem.

Look at the reference source to see the exception:
http://referencesource.microsoft.com/#System.Web/xsp/system/Web/HttpRequest.cs#d9b62e0b8c0ca2cd

After that fix it works for me properly.
