### PR TITLE
Support For AspNetSynchronizationContext

### DIFF
--- a/source/Glimpse.AspNet/AspNetFrameworkProvider.cs
+++ b/source/Glimpse.AspNet/AspNetFrameworkProvider.cs
@@ -71,16 +71,13 @@ namespace Glimpse.AspNet
 
         public void SetHttpResponseHeader(string name, string value)
         {
-            if (!Context.HeadersSent())
+            try
             {
-                try
-                {
-                    Context.Response.AppendHeader(name, value);
-                }
-                catch (Exception exception)
-                {
-                    Logger.Error("Exception setting Http response header '{0}' with value '{1}'.", exception, name, value);
-                }
+                Context.Response.AppendHeader(name, value);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error("Exception setting Http response header '{0}' with value '{1}'.", exception, name, value);
             }
         }
 

--- a/source/Glimpse.AspNet/Extensions/HttpContextExtensions.cs
+++ b/source/Glimpse.AspNet/Extensions/HttpContextExtensions.cs
@@ -5,8 +5,6 @@ namespace Glimpse.AspNet.Extensions
 {
     public static class HttpContextExtensions
     {
-        private const string HeadersSentKey = "__GlimpseHttpHeadersSent";
-
         public static string GenerateGlimpseScriptTags(this HttpContextBase context)
         {
             var generateScripts = context.Items["__GlimpseClientScriptsStrategy"] as Func<Guid?, string>;
@@ -17,18 +15,6 @@ namespace Glimpse.AspNet.Extensions
             }
 
             return generateScripts(null); // null means to use the current request id
-        }
-
-        internal static void HeadersSent(this HttpContextBase context, bool value)
-        {
-            context.Items[HeadersSentKey] = value;
-        }
-
-        internal static bool HeadersSent(this HttpContextBase context)
-        {
-            var result = context.Items[HeadersSentKey] as bool?;
-
-            return result.HasValue ? result.Value : false;
         }
     }
 }

--- a/source/Glimpse.AspNet/HttpModule.cs
+++ b/source/Glimpse.AspNet/HttpModule.cs
@@ -74,7 +74,6 @@ namespace Glimpse.AspNet
                 httpApplication.PostAcquireRequestState += (context, e) => BeginSessionAccess(WithTestable(context));
                 httpApplication.PostRequestHandlerExecute += (context, e) => EndSessionAccess(WithTestable(context));
                 httpApplication.PostReleaseRequestState += (context, e) => EndRequest(WithTestable(context));
-                httpApplication.PreSendRequestHeaders += (context, e) => SendHeaders(WithTestable(context));
             }
         }
 
@@ -113,11 +112,6 @@ namespace Glimpse.AspNet
             var runtime = GetRuntime(httpContext.Application);
 
             runtime.EndRequest();
-        }
-
-        internal void SendHeaders(HttpContextBase httpContext)
-        {
-            httpContext.HeadersSent(true);
         }
 
         private static HttpContextBase WithTestable(object sender)


### PR DESCRIPTION
When the new `AspNetSynchronizationContext` was introduced it became and anti-pattern to use `PreSendRequestHeaders` from a managed module.

You could control which synchronization context an app used with an app setting:

``` xml
<add key="aspnet:UseTaskFriendlySynchronizationContext" value="false" />
```

Instead of forcing users to use that setting, this pull request fixes #502 by removing our usage of `PreSendRequestHeaders`.

The ASP.NET team has [documented this](http://www.asp.net/aspnet/overview/web-development-best-practices/what-not-to-do-in-aspnet,-and-what-to-do-instead#presend) stating:

> You can use the `PreSendRequestHeaders` and `PreSendRequestContext` events with native IIS modules, but do not use them with managed modules that implement `IHttpModule`. **Setting these properties can cause issues with asynchronous requests.**

---

At this point I'm just looking to get "Ship It" squirrel or two. :shipit: 
