### PR TITLE
Fix #737 - Loosen GetDbProviderManifestToken behavior

### DIFF
--- a/source/Glimpse.EF/AlternateType/GlimpseDbProviderServices.cs
+++ b/source/Glimpse.EF/AlternateType/GlimpseDbProviderServices.cs
@@ -72,7 +72,9 @@ namespace Glimpse.EF.AlternateType
 
         protected override string GetDbProviderManifestToken(DbConnection connection)
         {
-            return InnerProviderServices.GetProviderManifestToken(((GlimpseDbConnection)connection).InnerConnection);
+            var glimpseConnection = connection as GlimpseDbConnection;
+            DbConnection rawConnection = glimpseConnection == null ? connection : glimpseConnection.InnerConnection;
+            return InnerProviderServices.GetProviderManifestToken(rawConnection);
         }
 
 #if (EF5 && NET45) || EF6Plus


### PR DESCRIPTION
Convert the cast to an 'as'. Seems reasonable to not cause the
application fail due to a bad interaction in what seems to be a lifetime
issue. Could also log a warning should you want to track this unexpected
case.
