### PR TITLE
Re-enable glimpse on owin sample for people without the cookie turned on

### DIFF
--- a/source/Glimpse.Owin.Sample/App.config
+++ b/source/Glimpse.Owin.Sample/App.config
@@ -6,9 +6,9 @@
   <glimpse defaultRuntimePolicy="On" endpointBaseUri="/Glimpse.axd">
     <logging level="Trace" />
     <runtimePolicies>
-      <!--<ignoredTypes>
+      <ignoredTypes>
         <add type="Glimpse.Core.Policy.ControlCookiePolicy, Glimpse.Core"/>
-      </ignoredTypes>-->
+      </ignoredTypes>
     </runtimePolicies>
   </glimpse>
     <startup> 


### PR DESCRIPTION
With these lines commented out, it is impossible to enable Glimpse on the owin sample.
