### PR TITLE
Validate Context.User.Identity before accessing it

### DIFF
--- a/source/Glimpse.AspNet/RequestMetadata.cs
+++ b/source/Glimpse.AspNet/RequestMetadata.cs
@@ -55,7 +55,7 @@ namespace Glimpse.AspNet
         { 
             get
             {
-                if (Context.User != null)
+                if (Context.User != null && Context.User.Identity != null)
                 {
                     var user = Context.User.Identity.Name;
                     if (!string.IsNullOrEmpty(user))


### PR DESCRIPTION
The Context.User.Identity can be null, if there is custom implementation. We should validate it to prevent NullReferenceException.