### PR TITLE
[WIP]change the default buffer size and the ordering of the requests

### DIFF
--- a/source/Glimpse.Core/Framework/ApplicationPersistenceStore.cs
+++ b/source/Glimpse.Core/Framework/ApplicationPersistenceStore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using Glimpse.Core.Extensibility;
 using Glimpse.Core.Extensions;
@@ -16,7 +17,12 @@ namespace Glimpse.Core.Framework
     {
         private const string PersistenceStoreKey = "__GlimpsePersistenceKey";
 
-        private const int BufferSize = 25;
+        private static readonly int BufferSize = new Func<int>(() =>
+        {
+            int bufferSize;
+            var bufferSizeConfig = ConfigurationManager.AppSettings["Glimpse:PersistenceStoreBufferSize"];
+            return int.TryParse(bufferSizeConfig, out bufferSize) ? bufferSize : 25;
+        })();
         
         private readonly object queueLock = new object();
 

--- a/source/Glimpse.Core/Framework/ApplicationPersistenceStore.cs
+++ b/source/Glimpse.Core/Framework/ApplicationPersistenceStore.cs
@@ -143,7 +143,7 @@ namespace Glimpse.Core.Framework
         {
             lock (queueLock)
             {
-                return GlimpseRequests.Take(count).ToList();
+                return GlimpseRequests.Reverse().Take(count).ToList();
             }
         }
 

--- a/source/Glimpse.Core/glimpse.js
+++ b/source/Glimpse.Core/glimpse.js
@@ -2715,7 +2715,7 @@ glimpse.tab = (function($, pubsub, data) {
                 detailBody.empty();
             }
             
-            for (var x = context.resultCount; x < clientData.length; x++) {
+            for (var x = (clientData.length - context.resultCount - 1); x >= 0 ; x--) {
                 var item = clientData[x];
                 html = '<tr class="glimpse-row" data-requestId="' + item.requestId + '"><td><div class="glimpse-ellipsis" title="' + item.uri + '">' + util.htmlEncode(item.uri) + '</div></td><td>' + item.method + '</td><td>' + item.statusCode + '</td><td class="mono" style="text-align:right">' + item.duration + '<span class="glimpse-soft"> ms</span></td><td>' + item.dateTime + '</td><td>' + item.isAjax + '</td><td><a href="javascript:void(0)" class="glimpse-history-link" data-requestId="' + item.requestId + '">Inspect</a></td></tr>' + html;
             }

--- a/source/Glimpse.Core/glimpse.js
+++ b/source/Glimpse.Core/glimpse.js
@@ -2405,7 +2405,7 @@ glimpse.tab = (function($, pubsub, data) {
         },
         activate = function() {
             var options = elements.optionsHolder().html('<div class="glimpse-clear"><a href="javascript:void(0)" class="glimpse-clear-ajax">Clear</a></div><div class="glimpse-notice glimpse-disconnect"><div class="icon"></div><span>Disconnected...</span></div>');
-            context.notice = util.connectionNotice(options.find('.glimpse-notice')); 
+            context.notice = util.connectionNotice(options.find('.glimpse-notice'));
              
             context.isSelected = true;
             
@@ -2600,7 +2600,7 @@ glimpse.tab = (function($, pubsub, data) {
     var context = { resultCount : 0, clientName : '', requestId : '', currentData: null, notice: null, isActive: false, isSelected: false, contextRequestId: undefined }, 
         generateHistoryAddress = function() {
             var currentMetadata = data.currentMetadata();
-            return util.uriTemplate(currentMetadata.resources.glimpse_history, { 'hash': currentMetadata.hash });
+            return util.uriTemplate(currentMetadata.resources.glimpse_history, { 'hash': currentMetadata.hash, 'top': $(".glimpse-options select").val() });
         },
         wireListeners = function() {
             var panel = elements.panel('history');
@@ -2616,7 +2616,9 @@ glimpse.tab = (function($, pubsub, data) {
         }, 
         activate = function() { 
             var options = elements.optionsHolder().html('<div class="glimpse-clear"><a href="javascript:void(0)" class="glimpse-clear-history">Clear</a></div><div class="glimpse-notice glimpse-disconnect"><div class="icon"></div><span>Disconnected...</span></div>');
-            context.notice = util.connectionNotice(options.find('.glimpse-notice')); 
+            // TODO:this is concept design, does not reflect Glimpse.Client repo
+            options.prepend('<div style="bottom:50px;position:absolute;right:20px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;border:#CCC solid 1px"><select name="history-size"><option>25</option><option selected="">50</option><option>100</option><option>250</option><option>500</option><option value="b"></option></select></div>');
+            context.notice = util.connectionNotice(options.find('.glimpse-notice'));
             
             context.isSelected = true;
             

--- a/source/Glimpse.Test.Core/ApplicationPersistenceStoreShould.cs
+++ b/source/Glimpse.Test.Core/ApplicationPersistenceStoreShould.cs
@@ -100,9 +100,13 @@ namespace Glimpse.Test.Core
             Store.Save(metadata4);
             Store.Save(metadata5);
 
-            var result = Store.GetTop(10);
+            var result = Store.GetTop(10).ToArray();
             Assert.Equal(5, result.Count());
-            Assert.Equal(metadata1, result.First());
+            Assert.Equal(metadata5, result[0]);
+            Assert.Equal(metadata4, result[1]);
+            Assert.Equal(metadata3, result[2]);
+            Assert.Equal(metadata2, result[3]);
+            Assert.Equal(metadata1, result[4]);
         }
 
         [Fact]
@@ -123,9 +127,11 @@ namespace Glimpse.Test.Core
             Store.Save(metadata4);
             Store.Save(metadata5);
 
-            var result = Store.GetTop(3);
+            var result = Store.GetTop(3).ToArray();
             Assert.Equal(3, result.Count());
-            Assert.Equal(metadata1, result.First());
+            Assert.Equal(metadata5, result[0]);
+            Assert.Equal(metadata4, result[1]);
+            Assert.Equal(metadata3, result[2]);
         }
 
         [Fact]


### PR DESCRIPTION
This pull request is improvement for WebService insights.

change the default buffer size
---
I changed ApplicationPersistenceStore.BufferSize to configurable.
The parameter take from AppSetting's `Glimpse:PersistenceStoreBufferSize` key.
This is same as `Glimpse:DisableAsyncSupport`.

change the ordering of the requests
---
I changed ApplicationPersistenceStore.GetTop to returns descending result and modified client script(glimpse.history.js)
Currently Glimpse's history tab shows descending result but API returns ascending result.
It cause Standalone mode shows oldest result at first.
In web service insights shows latest result is desirable.

Modifing ApplicationPersistenceStore.GetTop's behaviour is breaking change.
I thought some of the way.

* Add IReadOnlyPersistenceStore.GetLast, but it's big breaking change
* Add configuration `Glimpse:HistoryOrderMode` and conforming behaviour, it's too complex for user

I choose change the behaviour of GetTop.
Order to same the appearance of history tab, I was modified client script.
(Client script is not send pull request)

fetch history size
---
This pull request is not completed yet.
If spread bufferSize but shows history tab limit is 50.
HistoryResource.Execute handles GetTop parameter and "top" parameter maybe can't set from client.

* defaultSize change to same as ApplicationPersistenceStore.BufferSize (is this good or bad?)
* add selectBox(25,50,100,250,500) to above the clear button

I added selectbox in this pull request.

![glimpse_history_size](https://cloud.githubusercontent.com/assets/46207/6271054/96fbbe6e-b8a1-11e4-8005-eba6cb6e0594.png)

What do you think about this?
I want to your help.

Thank you.