### PR TITLE
Adds support for a configurable buffer size

### DIFF
--- a/source/Glimpse.Core/Configuration/Section.cs
+++ b/source/Glimpse.Core/Configuration/Section.cs
@@ -28,6 +28,7 @@ namespace Glimpse.Core.Configuration
     public class Section : ConfigurationSection
     {
         internal const string DefaultLocation = "";
+        internal const int DefaultBufferSize = 25;
 
         /// <summary>
         /// Gets or sets the logging settings used by Glimpse.
@@ -305,6 +306,28 @@ namespace Glimpse.Core.Configuration
         {
             get { return (string)base["discoveryLocation"]; }
             set { base["discoveryLocation"] = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the number of requests persisted by default.
+        /// </summary>
+        /// <remarks>
+        /// The <c>BufferSize</c> defaults to <c>25</c>. The <c>BufferSize</c> is leveraged by an instance of <see cref="IPersistenceStore"/> in order to persist the correct number of requests.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// <glimpse defaultRuntimePolicy="On" endpointBaseUri="~/Glimpse.axd" bufferSize="100">
+        ///     <!-- Additional Glimpse configuration nodes -->
+        /// </glimpse>
+        /// ]]>
+        /// </code>
+        /// </example>
+        [ConfigurationProperty("bufferSize", DefaultValue = DefaultBufferSize)]
+        public int BufferSize
+        {
+            get { return (int)base["bufferSize"]; }
+            set { base["bufferSize"] = value; }
         }
     }
 }

--- a/source/Glimpse.Core/Configuration/Section.cs
+++ b/source/Glimpse.Core/Configuration/Section.cs
@@ -312,22 +312,22 @@ namespace Glimpse.Core.Configuration
         /// Gets or sets the number of requests persisted by default.
         /// </summary>
         /// <remarks>
-        /// The <c>BufferSize</c> defaults to <c>25</c>. The <c>BufferSize</c> is leveraged by an instance of <see cref="IPersistenceStore"/> in order to persist the correct number of requests.
+        /// The <c>RequestBufferSize</c> defaults to <c>25</c>. The <c>RequestBufferSize</c> is leveraged by an instance of <see cref="IPersistenceStore"/> in order to persist the correct number of requests.
         /// </remarks>
         /// <example>
         /// <code>
         /// <![CDATA[
-        /// <glimpse defaultRuntimePolicy="On" endpointBaseUri="~/Glimpse.axd" bufferSize="100">
+        /// <glimpse defaultRuntimePolicy="On" endpointBaseUri="~/Glimpse.axd" requestBufferSize="100">
         ///     <!-- Additional Glimpse configuration nodes -->
         /// </glimpse>
         /// ]]>
         /// </code>
         /// </example>
-        [ConfigurationProperty("bufferSize", DefaultValue = DefaultBufferSize)]
-        public int BufferSize
+        [ConfigurationProperty("requestBufferSize", DefaultValue = DefaultBufferSize)]
+        public int RequestBufferSize
         {
-            get { return (int)base["bufferSize"]; }
-            set { base["bufferSize"] = value; }
+            get { return (int)base["requestBufferSize"]; }
+            set { base["requestBufferSize"] = value; }
         }
     }
 }

--- a/source/Glimpse.Core/Framework/Factory.cs
+++ b/source/Glimpse.Core/Framework/Factory.cs
@@ -247,7 +247,7 @@ namespace Glimpse.Core.Framework
                 return store;
             }
 
-            return new ApplicationPersistenceStore(InstantiateFrameworkProvider().HttpServerStore);
+            return new ApplicationPersistenceStore(InstantiateFrameworkProvider().HttpServerStore, Configuration.BufferSize);
         }
 
         /// <summary>

--- a/source/Glimpse.Core/Framework/Factory.cs
+++ b/source/Glimpse.Core/Framework/Factory.cs
@@ -247,7 +247,7 @@ namespace Glimpse.Core.Framework
                 return store;
             }
 
-            return new ApplicationPersistenceStore(InstantiateFrameworkProvider().HttpServerStore, Configuration.BufferSize);
+            return new ApplicationPersistenceStore(InstantiateFrameworkProvider().HttpServerStore, Configuration.RequestBufferSize);
         }
 
         /// <summary>

--- a/source/Glimpse.Test.Core/Framework/ApplicationPersistenceStoreShould.cs
+++ b/source/Glimpse.Test.Core/Framework/ApplicationPersistenceStoreShould.cs
@@ -5,7 +5,6 @@ using Glimpse.Core.Extensibility;
 using Glimpse.Core.Framework;
 using Glimpse.Test.Core.Tester;
 using Moq;
-using Ploeh.AutoFixture.Xunit;
 using Xunit;
 using Xunit.Extensions;
 

--- a/source/Glimpse.Test.Core/Framework/ApplicationPersistenceStoreShould.cs
+++ b/source/Glimpse.Test.Core/Framework/ApplicationPersistenceStoreShould.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using System.Threading;
 using Glimpse.Core.Extensibility;
 using Glimpse.Core.Framework;
+using Glimpse.Test.Core.Tester;
 using Moq;
+using Ploeh.AutoFixture.Xunit;
 using Xunit;
+using Xunit.Extensions;
 
 namespace Glimpse.Test.Core.Framework
 {
@@ -13,7 +16,7 @@ namespace Glimpse.Test.Core.Framework
         [Fact]
         public void BeThreadSafe()
         {
-            var sut = new ApplicationPersistenceStore(new DictionaryDataStoreAdapter(new Dictionary<string, object>()));
+            var sut = new ApplicationPersistenceStore(new DictionaryDataStoreAdapter(new Dictionary<string, object>()), 25);
 
             Action<ApplicationPersistenceStore> addingRequests = store =>
             {
@@ -63,6 +66,32 @@ namespace Glimpse.Test.Core.Framework
             {
                 invokedDelegate.Item1.EndInvoke(invokedDelegate.Item2);
             }
+        }
+
+        [Theory]
+        [InlineData(1, 10)]
+        [InlineData(10, 10)]
+        [InlineData(100, 10)]
+        [InlineData(1, 50)]
+        [InlineData(50, 50)]
+        [InlineData(100, 50)]
+        public void RespectTheBufferSize(int bufferSize, int requestCount)
+        {
+            var sut = ApplicationPersistenceStoreTester.Create(bufferSize);
+
+            var glimpseRequest = new GlimpseRequest(
+                Guid.NewGuid(),
+                new Mock<IRequestMetadata>().Object,
+                new Dictionary<string, TabResult>(),
+                new Dictionary<string, TabResult>(),
+                new TimeSpan(1000));
+
+            for (int i = 0; i < requestCount; i++)
+            {
+                sut.Save(glimpseRequest);
+            }
+
+            Assert.Equal(Math.Min(bufferSize, requestCount), sut.GlimpseRequests.Count);
         }
     }
 }

--- a/source/Glimpse.Test.Core/Tester/ApplicationPersistenceStoreTester.cs
+++ b/source/Glimpse.Test.Core/Tester/ApplicationPersistenceStoreTester.cs
@@ -10,7 +10,8 @@ namespace Glimpse.Test.Core.Tester
     {
         public Mock<IRequestMetadata> RequestMetadataMock { get; set; }
 
-        private ApplicationPersistenceStoreTester(IDataStore dataStore):base(dataStore)
+        private ApplicationPersistenceStoreTester(IDataStore dataStore, int bufferSize)
+            : base(dataStore, bufferSize)
         {
             RequestMetadataMock = new Mock<IRequestMetadata>();
             RequestMetadataMock.Setup(r => r.RequestHttpMethod).Returns("POST");
@@ -19,9 +20,9 @@ namespace Glimpse.Test.Core.Tester
             RequestMetadataMock.Setup(r => r.RequestIsAjax).Returns(true);
         }
 
-        public static ApplicationPersistenceStoreTester Create()
+        public static ApplicationPersistenceStoreTester Create(int bufferSize = 25)
         {
-            return new ApplicationPersistenceStoreTester(new DictionaryDataStoreAdapter(new Dictionary<object, object>()));
+            return new ApplicationPersistenceStoreTester(new DictionaryDataStoreAdapter(new Dictionary<object, object>()), bufferSize);
         }
     }
 }


### PR DESCRIPTION
Note: I started this work before I noticed PR https://github.com/Glimpse/Glimpse/pull/883; however, that PR has been inactive for 13 days so I thought I'd finish off the configurable request count aspect of it.

This adds support for a configurable buffer size by adding a `BufferSize` property to the configuration `Section`.

Example usage:

        <glimpse defaultRuntimePolicy="On" endpointBaseUri="~/Glimpse.axd" requestBufferSize="100">
            <!-- Additional Glimpse configuration nodes -->
        </glimpse>