### PR TITLE
Sets executed type as the `EventSubText` for `ISourceMessages` on the Timeline

### DIFF
--- a/source/Glimpse.Mvc/Message/MvcTimelineExtension.cs
+++ b/source/Glimpse.Mvc/Message/MvcTimelineExtension.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using Glimpse.Core.Message;
 using Glimpse.Mvc.AlternateType;
 
@@ -21,6 +18,12 @@ namespace Glimpse.Mvc.Message
             {
                 controllerName = actionMessage.ControllerName;
                 actionName = actionMessage.ActionName;
+            }
+
+            var sourceMessage = message as ISourceMessage;
+            if (sourceMessage != null)
+            {
+                message.EventSubText = sourceMessage.ExecutedType.ToString();
             }
 
             var viewRenderMessage = message as View.Render.Message;


### PR DESCRIPTION
The problem:

![image](http://i.gyazo.com/1cfe75042a9b1a6cb5f2155420990efe.gif)

It is impossible to tell from the Timeline view which filters relate to which timing event. This means that the user needs to switch to the Execution tab to get this data.

The solution:

We already have this data in the message (because it's rendered in the Execution tab), so we can assign this value to the EventSubText property of the TimelineMessage:

![image](https://cloud.githubusercontent.com/assets/2872984/6751818/8fe843ca-cf00-11e4-972b-540b0c9494ef.png)


This also adds the full controller type name, as well as the type of Action Result:

![image](http://i.gyazo.com/aea6ac07c9c694cf08b430cc080cfc46.gif)


