### PR TITLE
Page adapters without qualifying assembly name

### DIFF
--- a/source/Glimpse.WebForms/Support/ViewStateFormatter.cs
+++ b/source/Glimpse.WebForms/Support/ViewStateFormatter.cs
@@ -16,7 +16,7 @@ namespace Glimpse.WebForms.Support
 
         protected ILogger Logger
         {
-            get { return logger ?? (logger = GlimpseConfiguration.GetLogger()); }
+            get { return logger ?? (logger = GlimpseConfiguration.GetLogger()); } 
         }
 
         public void Process(ControlTreeItemTrackModel root)
@@ -27,9 +27,9 @@ namespace Glimpse.WebForms.Support
             var controlTypes = HttpContext.Current.Items["_GlimpseWebFormControlTreeType"] as Dictionary<string, Type>;
 
             if (viewState != null && root.Children.Count > 0)
-            {
+            { 
                 Logger.Debug("Process Root node for viewState data to the ControlTree mapping");
-                ProcessRecord(root.Children[0], viewState, controlTypes);
+                ProcessRecord(root.Children[0], viewState, controlTypes); 
             }
 
             Logger.Debug("Finish merging in the viewState data to the ControlTree");
@@ -57,7 +57,7 @@ namespace Glimpse.WebForms.Support
                 {
                     var triplet = (Triplet)viewstate;
                     item.Record.Viewstate = ProcessData(controlTypes[item.ControlId], item.Record.Type, triplet.First);
-
+                        
                     // NEED TO DO SOMETHING WITH SECOND ITEM?
                     ProcessRecord(item, triplet.Third, controlTypes);
                 }
@@ -109,10 +109,10 @@ namespace Glimpse.WebForms.Support
                             temp.Add("Model Data Source State", ProcessData(rootType, "System.Web.UI.WebControls.MethodParametersDictionary", pair.Second));
                             result = temp;
                         }
-                    }
+                    } 
                 }
                 else if (data is Pair && (type == "System.Web.UI.WebControls.WebControl" || type == "System.Web.UI.UserControl"))
-                {
+                { 
                     var pair = data as Pair;
                     if (pair != null && (pair.First != null || pair.Second != null))
                     {
@@ -122,7 +122,7 @@ namespace Glimpse.WebForms.Support
                             var temp = new Dictionary<string, object>();
                             temp.Add("Base State", result);
                             temp.Add("Attribute State", WrapProcessedData(pair.Second));
-                            result = temp;
+                            result = temp; 
                         }
                     }
                 }
@@ -164,7 +164,7 @@ namespace Glimpse.WebForms.Support
                     {
                         var temp = new Dictionary<string, object>();
                         temp.Add("Base State", pair.First);
-                        temp.Add("Model Data Source State", ProcessData(rootType, "System.Web.UI.WebControls.ModelDataSource", pair.Second));
+                        temp.Add("Model Data Source State", ProcessData(rootType, "System.Web.UI.WebControls.ModelDataSource", pair.Second)); 
                         result = temp;
                     }
                 }
@@ -210,7 +210,7 @@ namespace Glimpse.WebForms.Support
                         else
                         {
                             result = triplet;
-                        }
+                        } 
                     }
                     else
                     {
@@ -233,7 +233,7 @@ namespace Glimpse.WebForms.Support
                             else
                             {
                                 result = pair;
-                            }
+                            } 
                         }
                     }
                 }
@@ -259,7 +259,7 @@ namespace Glimpse.WebForms.Support
                     result = ProcessData(rootType, "System.Web.UI.WebControls.DataBoundControl", data);
                 }
                 else if (type == "System.Web.UI.WebControls.FormView")
-                {
+                { 
                     var list = data as IList;
                     if (list != null && list.Count == 10)
                     {
@@ -278,9 +278,9 @@ namespace Glimpse.WebForms.Support
                         result = temp;
                     }
                 }
-                else if (type == "System.Web.UI.WebControls.DetailsView")
-                {
-                    var list = data as object[];
+                else if (type == "System.Web.UI.WebControls.DetailsView") 
+                { 
+                    var list = data as object[]; 
                     if (list != null && list.Length == 15)
                     {
                         var temp = new Dictionary<string, object>();
@@ -294,23 +294,23 @@ namespace Glimpse.WebForms.Support
                         temp.Add("Edit Row Style", WrapProcessedData(list[7]));
                         temp.Add("Insert Row Style", WrapProcessedData(list[8]));
                         temp.Add("Field Header Style", WrapProcessedData(list[9]));
-                        temp.Add("Field Collection", list[10]);  // Could do more here
-                        temp.Add("Bound Field Style", ProcessData(rootType, "System.Web.UI.OrderedDictionaryStateHelper", list[11]));
+                        temp.Add("Field Collection", list[10]);  // Could do more here 
+                        temp.Add("Bound Field Style", ProcessData(rootType, "System.Web.UI.OrderedDictionaryStateHelper", list[11])); 
                         temp.Add("Pager Settings", WrapProcessedData(list[12]));
                         temp.Add("Control Style", WrapProcessedData(list[13]));
-                        temp.Add("Rows Generator", list[14]); // Could do more here
+                        temp.Add("Rows Generator", list[14]); // Could do more here 
 
                         result = temp;
-                    }
+                    } 
                 }
                 else if (type == "System.Web.UI.WebControls.GridView")
-                {
+                { 
                     var list = data as object[];
                     if (list != null && list.Length == 16)
                     {
                         var temp = new Dictionary<string, object>();
                         temp.Add("Base State", ProcessData(rootType, "System.Web.UI.WebControls.CompositeDataBoundControl", list[0]));
-                        temp.Add("Field Collection", list[1]); // Could do more here
+                        temp.Add("Field Collection", list[1]); // Could do more here 
                         temp.Add("Pager Style", WrapProcessedData(list[2]));
                         temp.Add("Header Style", WrapProcessedData(list[3]));
                         temp.Add("Footer Style", WrapProcessedData(list[4]));
@@ -321,7 +321,7 @@ namespace Glimpse.WebForms.Support
                         temp.Add("Bound Field Values", ProcessData(rootType, "System.Web.UI.OrderedDictionaryStateHelper", list[9]));
                         temp.Add("Pager Settings", WrapProcessedData(list[10]));
                         temp.Add("Control Style Created", WrapProcessedData(list[11]));
-                        temp.Add("Columns Generator", list[12]); // Could do more here
+                        temp.Add("Columns Generator", list[12]); // Could do more here 
                         temp.Add("Sorted Ascending Cell Style", WrapProcessedData(list[13]));
                         temp.Add("Sorted Descending Cell Style", WrapProcessedData(list[14]));
                         temp.Add("Sorted Ascending Header Style", WrapProcessedData(list[15]));
@@ -352,7 +352,7 @@ namespace Glimpse.WebForms.Support
                         temp.Add("Level Menu Item Styles", WrapProcessedData(list[9]));
                         temp.Add("Level Selected Styles", WrapProcessedData(list[10]));
                         temp.Add("Level Styles", WrapProcessedData(list[11]));
-                        temp.Add("Items", list[12]); // Could do more here
+                        temp.Add("Items", list[12]); // Could do more here 
 
                         result = temp;
                     }
@@ -371,13 +371,13 @@ namespace Glimpse.WebForms.Support
                         temp.Add("Selected Node Style", WrapProcessedData(list[5]));
                         temp.Add("Hover Node Style", WrapProcessedData(list[6]));
                         temp.Add("Level Style", WrapProcessedData(list[7]));
-                        temp.Add("Nodes", list[8]); // Could do more here
+                        temp.Add("Nodes", list[8]); // Could do more here 
 
                         result = temp;
                     }
                 }
                 else if (type == "System.Web.UI.WebControls.DataGrid")
-                {
+                { 
                     var list = data as object[];
                     if (list != null && list.Length == 11)
                     {
@@ -392,7 +392,7 @@ namespace Glimpse.WebForms.Support
                         temp.Add("Selected Item Style", WrapProcessedData(list[7]));
                         temp.Add("Edit Item Style", WrapProcessedData(list[8]));
                         temp.Add("Control Style", WrapProcessedData(list[9]));
-                        temp.Add("Auto Generated Columns", list[10]); // Could do more here
+                        temp.Add("Auto Generated Columns", list[10]); // Could do more here 
 
                         result = temp;
                     }
@@ -414,12 +414,12 @@ namespace Glimpse.WebForms.Support
                     }
                 }
                 else if (type == "System.Web.UI.WebControls.DataList")
-                {
+                { 
                     var list = data as object[];
                     if (list != null && list.Length == 9)
                     {
                         var temp = new Dictionary<string, object>();
-                        temp.Add("Base State", ProcessData(rootType, "System.Web.UI.WebControls.WebControls", list[0]));
+                        temp.Add("Base State", ProcessData(rootType, "System.Web.UI.WebControls.WebControls", list[0])); 
                         temp.Add("Item Style", WrapProcessedData(list[1]));
                         temp.Add("Selected Item Style", WrapProcessedData(list[2]));
                         temp.Add("Alternating Item Style", WrapProcessedData(list[3]));
@@ -427,10 +427,10 @@ namespace Glimpse.WebForms.Support
                         temp.Add("Separator Style", WrapProcessedData(list[5]));
                         temp.Add("Header Style", WrapProcessedData(list[6]));
                         temp.Add("Footer Style", WrapProcessedData(list[7]));
-                        temp.Add("Control Style", WrapProcessedData(list[8]));
+                        temp.Add("Control Style", WrapProcessedData(list[8])); 
 
                         result = temp;
-                    }
+                    } 
                 }
                 else if (type == "System.Web.UI.OrderedDictionaryStateHelper")
                 {
@@ -440,8 +440,8 @@ namespace Glimpse.WebForms.Support
                         var temp = new Dictionary<object, object>();
                         foreach (var item in list)
                         {
-                            var pair = item as Pair;
-                            temp.Add(pair.First, pair.Second);
+                            var pair = item as Pair; 
+                            temp.Add(pair.First, pair.Second);  
                         }
                     }
                 }
@@ -527,7 +527,7 @@ namespace Glimpse.WebForms.Support
         {
             public object Index { get; set; }
 
-            public object Data { get; set; }
+            public object Data { get; set; } 
         }
     }
 }

--- a/source/Glimpse.WebForms/Tab/ControlTree.cs
+++ b/source/Glimpse.WebForms/Tab/ControlTree.cs
@@ -18,8 +18,8 @@ namespace Glimpse.WebForms.Tab
 {
     public class ControlTree : AspNetTab, ITabSetup, ITabLayout, IKey
     {
-        private static readonly MethodInfo traceContextVerifyStartMethod = typeof(System.Web.TraceContext).GetMethod("VerifyStart", BindingFlags.Instance | BindingFlags.NonPublic);
-        private static readonly FieldInfo requestDataField = typeof(System.Web.TraceContext).GetField("_requestData", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly MethodInfo traceContextVerifyStartMethod = typeof(TraceContext).GetMethod("VerifyStart", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly FieldInfo requestDataField = typeof(TraceContext).GetField("_requestData", BindingFlags.Instance | BindingFlags.NonPublic);
         private static readonly ViewStateFormatter viewStateFormatter = new ViewStateFormatter();
         private static readonly DataBindFormatter dataBindFormatter = new DataBindFormatter();
 
@@ -78,7 +78,7 @@ namespace Glimpse.WebForms.Tab
                 context.TabStore.Set("hasRun", "true");
 
                 // Remember the previous state, turn tracing on at the begining of the request,
-                // set things up so that when request is finished, lets put things back to the 
+                // set things up so that when request is finished, lets put things back to the
                 // way they where. Lastly, make sure sate of trace is setup
                 context.Logger.Debug("Setting logger infrastructure - previouslyEnabled = {0}", trace.IsEnabled);
 
@@ -123,7 +123,7 @@ namespace Glimpse.WebForms.Tab
 
         private void RegisterAdapters(ITabContext context)
         {
-            // Add adapter to the pipeline as a ViewStatePageAdapter 
+            // Add adapter to the pipeline as a ViewStatePageAdapter
             context.Logger.Debug("Setting up view state page adapter");
 
             var adapters = HttpContext.Current.Request.Browser.Adapters;
@@ -137,10 +137,31 @@ namespace Glimpse.WebForms.Tab
             {
                 var existingTypeString = (string)adapters[keyType.AssemblyQualifiedName];
                 var existingType = Type.GetType(existingTypeString);
-                if ((!existingType.IsGenericType && existingType != typeof(ViewStatePageAdapter)) || (existingType.IsGenericType && existingType.GetGenericTypeDefinition() != typeof(ViewStatePageAdapter<>)))
+                if (existingType == null)
                 {
-                    var newAdapterType = typeof(ViewStatePageAdapter<>).MakeGenericType(existingType);
-                    adapters[keyType.AssemblyQualifiedName] = newAdapterType.AssemblyQualifiedName;
+                    // Try resolving type against primary web application assembly (eg. if adapter configuration was not assembly qualified)
+                    var instance = HttpContext.Current.ApplicationInstance;
+                    var baseType = instance.GetType().BaseType;
+                    if (baseType != null)
+                    {
+                        var rootAssembly = baseType.Assembly;
+                        existingType = rootAssembly.GetType(existingTypeString);
+                    }
+                }
+
+                if (existingType != null)
+                {
+                    if ((!existingType.IsGenericType && existingType != typeof(ViewStatePageAdapter)) ||
+                        (existingType.IsGenericType &&
+                         existingType.GetGenericTypeDefinition() != typeof(ViewStatePageAdapter<>)))
+                    {
+                        var newAdapterType = typeof(ViewStatePageAdapter<>).MakeGenericType(existingType);
+                        adapters[keyType.AssemblyQualifiedName] = newAdapterType.AssemblyQualifiedName;
+                    }
+                }
+                else
+                {
+                    context.Logger.Error("Failed to resolve type {0}", existingTypeString);
                 }
             }
 

--- a/source/Glimpse.WebForms/Tab/ControlTree.cs
+++ b/source/Glimpse.WebForms/Tab/ControlTree.cs
@@ -78,7 +78,7 @@ namespace Glimpse.WebForms.Tab
                 context.TabStore.Set("hasRun", "true");
 
                 // Remember the previous state, turn tracing on at the begining of the request,
-                // set things up so that when request is finished, lets put things back to the
+                // set things up so that when request is finished, lets put things back to the 
                 // way they where. Lastly, make sure sate of trace is setup
                 context.Logger.Debug("Setting logger infrastructure - previouslyEnabled = {0}", trace.IsEnabled);
 
@@ -123,7 +123,7 @@ namespace Glimpse.WebForms.Tab
 
         private void RegisterAdapters(ITabContext context)
         {
-            // Add adapter to the pipeline as a ViewStatePageAdapter
+            // Add adapter to the pipeline as a ViewStatePageAdapter 
             context.Logger.Debug("Setting up view state page adapter");
 
             var adapters = HttpContext.Current.Request.Browser.Adapters;


### PR DESCRIPTION
Resolve #903

* Handle the case where a page adapter is configured without a qualifying assembly name, and attempt to resolve the type in the main web application assembly.
* Avoid KeyNotFoundExceptions when processing view state