### PR TITLE
Avoid InvalidOperationException

### DIFF
--- a/source/Glimpse.WebForms/Display/WebForms.cs
+++ b/source/Glimpse.WebForms/Display/WebForms.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq; 
+using System.Linq;
+using Glimpse.AspNet.Extensions;
 using Glimpse.Core.Extensibility;
 using Glimpse.Core.Extensions;
 using Glimpse.WebForms.Inspector;
 
 namespace Glimpse.WebForms.Display
-{ 
+{
     [Obsolete]
     public class WebForms : IDisplay, ITabSetup, IKey
     {
@@ -29,23 +30,31 @@ namespace Glimpse.WebForms.Display
 
         public object GetData(ITabContext context)
         {
-            var data = ProcessData(context.GetMessages<PageLifeCycleMessage>());
+            var data = ProcessData(context.GetMessages<PageLifeCycleMessage>(), context);
             return data;
         }
 
-        private object ProcessData(IEnumerable<PageLifeCycleMessage> webFormsMessages)
+        private object ProcessData(IEnumerable<PageLifeCycleMessage> webFormsMessages, ITabContext context)
         {
-            var loadingList = webFormsMessages.Where(x => x.EventName.Contains("Load")); 
-            var loadingFirst = loadingList.First();
-            var loadingLast = loadingList.Last();
-            var loadingTime = loadingLast.Offset - loadingFirst.Offset;
+            var messages = webFormsMessages as IList<PageLifeCycleMessage> ?? webFormsMessages.ToList();
+            var loadingList = messages.Where(x => x.EventName.Contains("Load")).ToList();
+            var renderingList = messages.Where(x => x.EventName.Contains("Render") || x.EventName.Contains("State")).ToList();
 
-            var renderingList = webFormsMessages.Where(x => x.EventName.Contains("Render") || x.EventName.Contains("State"));
-            var renderingFirst = renderingList.First();
-            var renderingLast = renderingList.Last();
-            var renderingTime = renderingLast.Offset - renderingFirst.Offset;
-             
-            return new { loadingTime, renderingTime };
+            if (loadingList.Any() && renderingList.Any())
+            {
+                var loadingFirst = loadingList.First();
+                var loadingLast = loadingList.Last();
+                var loadingTime = loadingLast.Offset - loadingFirst.Offset;
+
+                var renderingFirst = renderingList.First();
+                var renderingLast = renderingList.Last();
+                var renderingTime = renderingLast.Offset - renderingFirst.Offset;
+
+                return new {loadingTime, renderingTime};
+            }
+
+            context.Logger.Warn("No page lifecycle messages found for {0}", context.GetHttpContext().Request.RawUrl);
+            return null;
         }
     }
 }

--- a/source/Glimpse.WebForms/Display/WebForms.cs
+++ b/source/Glimpse.WebForms/Display/WebForms.cs
@@ -50,7 +50,7 @@ namespace Glimpse.WebForms.Display
                 var renderingLast = renderingList.Last();
                 var renderingTime = renderingLast.Offset - renderingFirst.Offset;
 
-                return new {loadingTime, renderingTime};
+                return new { loadingTime, renderingTime };
             }
 
             context.Logger.Warn("No page lifecycle messages found for {0}", context.GetHttpContext().Request.RawUrl);


### PR DESCRIPTION
Sometimes there are no matching PageLifeCycleEventMessage messages. Return null and log warning.
One cause of this scenario can be calling a .asmx service

Fixes #910