### PR TITLE
Serialization not working when many ToString() methods

### DIFF
--- a/source/Glimpse.AspNet/Support/Serialization.cs
+++ b/source/Glimpse.AspNet/Support/Serialization.cs
@@ -11,7 +11,7 @@ namespace Glimpse.AspNet.Support
                 var type = value.GetType();
                 if (!type.IsSerializable)
                 {
-                    if (type.GetMethod("ToString").DeclaringType == type)
+                    if (type.GetMethod("ToString", new Type[0]).DeclaringType == type)
                     {
                         value = value.ToString();
                     }


### PR DESCRIPTION
found the following exception in the logs: 

`2016-04-14 16:25:24.9918 | FATAL | Error executing resource result of type 'Glimpse.Core.ResourceResult.CacheControlDecorator'. | System.Reflection.AmbiguousMatchException--Correspondance ambiguë trouvée.--   à System.RuntimeType.GetMethodImpl(String name, BindingFlags bindingAttr, Binder binder, [...]`

The problem was linked to one of my class having more than one ToString() method.